### PR TITLE
Fix manifest generation and add languages.json to new projects

### DIFF
--- a/src/components/Projects/CreateProject/Files/Lang.ts
+++ b/src/components/Projects/CreateProject/Files/Lang.ts
@@ -14,5 +14,10 @@ export class CreateLang extends CreateFile {
 			`${this.packPath}/texts/en_US.lang`,
 			`pack.name=${createOptions.name} ${this.packPath}\npack.description=${createOptions.description}`
 		)
+		await fs.writeJSON(
+			`${this.packPath}/texts/languages.json`,
+			['en_US'],
+			true
+		)
 	}
 }

--- a/src/components/Projects/CreateProject/Files/Manifest.ts
+++ b/src/components/Projects/CreateProject/Files/Manifest.ts
@@ -29,8 +29,10 @@ export class CreateManifest extends CreateFile {
 					name: 'pack.name',
 					description: 'pack.description',
 					min_engine_version:
-						this.type === 'data'
-							? [1, 13, 0]
+						this.type === 'data' || 'resources'
+							? createOptions.targetVersion
+								.split('.')
+								.map(str => Number(str))
 							: undefined,
 					uuid: uuid(),
 					version: [1, 0, 0],
@@ -44,7 +46,7 @@ export class CreateManifest extends CreateFile {
 					},
 				],
 			},
-			true
+			true,
 		)
 	}
 }


### PR DESCRIPTION
## Description
This PR adds the following:
- Create the languages.json file for new projects with `en_US` as entry.
- Add `min_engine_version` to the Rp manifest. This is needed to make sure the pack shows up inside Minecraft.
- I also changed 1.13.0 back to the target version selected, because this should be the version you are developing against.

## Motivation and Context
These changes are needed to show the packs properly inside Minecraft.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
