### PR TITLE
Update en.ts

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -314,7 +314,7 @@ export default {
 		selectFolder: {
 			title: 'Select Folder',
 			content:
-				'Select where to save projects or choose an existing projects directory.',
+				'Select where to save projects or choose an existing projects directory. This should not be the "com.mojang" folder, but rather a new folder specifically for bridge.',
 			select: 'Select!',
 		},
 		packExplorer: {


### PR DESCRIPTION
Clarify projects directory, should reduce confusion on why "com.mojang" isn't working for users

## Motivation and Context
Many users in the official bridge. Discord server attempt to use said folder, so many more than those who bring it up there also experience the issue.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have tested my changes and confirmed that they are working
