### PR TITLE
feat: Added "multiple" file input option to Presets Window

### DIFF
--- a/src/components/Windows/Project/CreatePreset/PresetWindow.ts
+++ b/src/components/Windows/Project/CreatePreset/PresetWindow.ts
@@ -43,6 +43,7 @@ export interface IPresetFieldOpts {
 	// type = 'fileInput'
 	accept: string
 	icon: string
+	multiple?: boolean
 }
 
 export interface IPresetFileOpts {

--- a/src/components/Windows/Project/CreatePreset/PresetWindow.vue
+++ b/src/components/Windows/Project/CreatePreset/PresetWindow.vue
@@ -73,6 +73,7 @@
 						:prepend-icon="null"
 						:prepend-inner-icon="opts.icon || 'mdi-paperclip'"
 						:label="name"
+						:multiple="opts.multiple || false"
 						autocomplete="off"
 						outlined
 						dense


### PR DESCRIPTION
# Feature: Added "multiple" option to presets file input fields
- Added an optional `multiple` boolean value to the `IPresetFieldOpts` interface.
- Added a corresponding `multiple` prop to the Preset Window's `v-file-input`

## Description
Modified the project presets window to accept multiple files in the file input. Setting the file input field's new `multiple` option to `true` will add the `multiple` prop to the field's `v-file-input`. An array of `File` objects is passed to the preset script.

#### TODO
Presets documentation will need to be updated.

## Motivation and Context
This is a minor change which will allow more options for bridge. preset authors. I personally intend to use it in upcoming changes to the Texture Set Generator extension.

## Screenshots (if appropriate):
![Preset Multiple File Input](https://user-images.githubusercontent.com/1903667/134071488-ccd9eb66-bbc7-403d-9995-7c34c289d3bf.png)
![Preset manifest](https://user-images.githubusercontent.com/1903667/134071511-8d17c92d-2d6b-4e3f-a3ad-8307aa92377f.png)
![create.js script from manifest](https://user-images.githubusercontent.com/1903667/134071534-0f778060-cd29-4504-82af-0c3deaa4bf91.png)
![create.js output](https://user-images.githubusercontent.com/1903667/134071559-31c3b474-6b85-4fdf-b878-4faa975b7828.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
