### PR TITLE
fix: new file error

### DIFF
--- a/src/components/Windows/Project/CreatePreset/PresetWindow.ts
+++ b/src/components/Windows/Project/CreatePreset/PresetWindow.ts
@@ -62,7 +62,7 @@ export interface IPermissions {
 export class CreatePresetWindow extends BaseWindow {
 	protected loadPresetPaths = new Map<string, string>()
 	protected sidebar = new Sidebar([])
-	protected shouldReloadPresets = false
+	protected shouldReloadPresets = true
 	protected modelResetters: (() => void)[] = []
 
 	/**


### PR DESCRIPTION
## Description
Changed default value of shouldReloadPresets to true to initialize state of new preset window instance

## Motivation and Context
If set to false state of preset window returns an empty object causing undefined errors when user tries to add a new file to the project where after the app freezes completely.
Refer to issue #67 and #68 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
