### PR TITLE
feat: Added basic TGA image support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"monaco-editor": "^0.28.1",
 		"path-browserify": "^1.0.1",
 		"prismarine-nbt": "^1.6.0",
+		"tga-js": "^1.1.1",
 		"three": "^0.127.0",
 		"uuid": "^8.3.1",
 		"vue": "2.6.12",

--- a/src/components/Editors/Image/TargaTab.ts
+++ b/src/components/Editors/Image/TargaTab.ts
@@ -1,0 +1,27 @@
+import { ImageTab } from './ImageTab'
+import { AnyFileHandle } from '../../FileSystem/Types'
+import TgaLoader from 'tga-js'
+
+export class TargaTab extends ImageTab {
+	static is(fileHandle: AnyFileHandle) {
+		const fileName = fileHandle.name
+		return fileName.endsWith('.tga') || fileName.endsWith('.targa')
+	}
+
+	async onActivate() {
+		const loader = new TgaLoader()
+		const file = await this.fileHandle.getFile()
+
+		loader.load(new Uint8Array(await file.arrayBuffer()))
+
+		this.dataUrl = loader.getDataURL('image/png')
+	}
+
+	save() {
+		/// TODO: Save `this.dataUrl` value to `${this.fileHandle.name}.png` file
+	}
+
+	async saveAs() {
+		/// TODO: Save `this.dataUrl` value to user input
+	}
+}

--- a/src/components/TabSystem/TabProvider.ts
+++ b/src/components/TabSystem/TabProvider.ts
@@ -1,4 +1,5 @@
 import { ImageTab } from '../Editors/Image/ImageTab'
+import { TargaTab } from '../Editors/Image/TargaTab'
 import { TextTab } from '../Editors/Text/TextTab'
 import { TreeTab } from '../Editors/TreeEditor/Tab'
 import { FileTab } from './FileTab'
@@ -8,6 +9,7 @@ export class TabProvider {
 		TextTab,
 		TreeTab,
 		ImageTab,
+		TargaTab,
 	])
 	static get tabs() {
 		return [...this._tabs].reverse()


### PR DESCRIPTION
## Description
- Added .tga viewing support to editor image tabs
  - Extended ImageTab class to create TargaTab class
  - Registered TargaTab in TabProvider
- Requires tga-js as a dependency

### TODO
- Implement `save` and `saveAs` methods
- Create option to toggle/adjust alpha transparency
- Move process to web worker and utilize OffscreenCanvas

## Motivation and Context
- Addresses #163 

## Screenshots (if appropriate):
![Feature example](https://user-images.githubusercontent.com/1903667/138354941-4d08977a-a3f5-43c5-80df-261b52a649e7.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have tested my changes and confirmed that they are working
