### PR TITLE
upd: update SoundDefinitions.ts

### DIFF
--- a/src/components/Projects/CreateProject/Files/RP/SoundDefinitions.ts
+++ b/src/components/Projects/CreateProject/Files/RP/SoundDefinitions.ts
@@ -10,6 +10,7 @@ export class CreateSoundDefintions extends CreateFile {
 		await fs.writeJSON(
 			`RP/sounds/sound_definitions.json`,
 			{
+				format_version: '1.14.0',
 				sound_definitions: {},
 			},
 			true


### PR DESCRIPTION
## Description
Add the `format_version` object for `sound_definitions.json` files created with projects. `1.14.0` is the format version used in the vanilla _Minecraft_ file and is supported in the latest stable and preview versions.

## Motivation and Context
_Minecraft_ doesn't read `sound_definitions.json` without a format version.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have tested my changes and confirmed that they are working
