### PR TITLE
fix: virtual project activation

### DIFF
--- a/src/components/Projects/Project/Project.ts
+++ b/src/components/Projects/Project/Project.ts
@@ -191,8 +191,6 @@ export abstract class Project {
 	) {
 		if (!this.isVirtualProject) await this.app.comMojang.fired
 
-		await this.app.comMojang.fired
-
 		const compiler = await new DashCompiler(
 			this.app.fileSystem.baseDirectory,
 			this.app.comMojang.hasComMojang


### PR DESCRIPTION
We should not await the com.mojang setup for the virtual project ("Home Project"). This e.g. fixes an infinite loading bug of the extension store without a selected project.

TODO: Test whether com.mojang syncing still works correctly