### PR TITLE
feat: always show available compiler plugin names

### DIFF
--- a/src/components/Windows/ExtensionStore/ExtensionCard.vue
+++ b/src/components/Windows/ExtensionStore/ExtensionCard.vue
@@ -126,42 +126,41 @@
 
 		<span>{{ extension.description }}</span>
 
-		<template
+		<v-divider
 			v-if="
-				(extension.connected &&
-					extension.connected.contributesCompilerPlugins) ||
+				extension.compilerPlugins.length > 0 ||
 				!extension.isCompatibleVersion()
 			"
+			class="my-2"
+		/>
+
+		<div
+			class="d-flex align-center"
+			v-if="extension.compilerPlugins.length > 0"
 		>
-			<v-divider class="my-2" />
+			<v-icon class="pr-1" color="secondary">mdi-cogs</v-icon>
+			<span class="font-weight-bold">
+				{{
+					t(
+						'windows.extensionStore.compilerPluginDownload.compilerPlugins'
+					)
+				}}:&nbsp;
+			</span>
 
-			<div
-				v-if="
-					extension.connected &&
-					extension.connected.contributesCompilerPlugins
-				"
+			<span>
+				{{ compilerPlugins }}
+			</span>
+		</div>
+
+		<div
+			v-if="!extension.isCompatibleVersion()"
+			class="d-flex align-center pt-1"
+		>
+			<v-icon class="pr-1" color="error">mdi-alert-circle</v-icon>
+			<span class="font-weight-bold">
+				{{ t('windows.extensionStore.incompatibleVersion') }}</span
 			>
-				<v-icon color="secondary">mdi-format-list-bulleted</v-icon>
-				<span class="font-weight-bold">
-					{{
-						t(
-							'windows.extensionStore.compilerPluginDownload.compilerPlugins'
-						)
-					}}:
-				</span>
-
-				<span>
-					{{ compilerPlugins }}
-				</span>
-			</div>
-
-			<div v-if="!extension.isCompatibleVersion()" class="pt-1">
-				<span class="font-weight-bold">
-					<v-icon color="error">mdi-alert-circle</v-icon>
-					{{ t('windows.extensionStore.incompatibleVersion') }}</span
-				>
-			</div>
-		</template>
+		</div>
 	</div>
 </template>
 
@@ -195,7 +194,7 @@ export default {
 			return this.$vuetify.breakpoint.mobile
 		},
 		compilerPlugins() {
-			return Object.keys(this.extension.connected.compilerPlugins)
+			return this.extension.compilerPlugins
 				.map((plugin) => `"${plugin}"`)
 				.join(', ')
 		},

--- a/src/components/Windows/ExtensionStore/ExtensionViewer.ts
+++ b/src/components/Windows/ExtensionStore/ExtensionViewer.ts
@@ -64,6 +64,12 @@ export class ExtensionViewer {
 	}
 	//#endregion
 
+	get compilerPlugins() {
+		const ext = this.extension
+		if(ext) return Object.keys(ext.compilerPlugins ?? {})
+
+		return Object.keys(this.config?.compiler?.plugins ?? {})
+	}
 	get isInstalled() {
 		return this._isInstalled
 	}


### PR DESCRIPTION
This PR changes the extension card viewer to always show the names of compiler plugins within the extension. Previously, this UI only showed up for installed extensions after closing & then re-opening the extension store.

<img width="775" alt="Bildschirmfoto 2022-10-11 um 22 15 38" src="https://user-images.githubusercontent.com/33347616/195189778-8787da2b-74eb-45aa-829d-680337bcde00.png">
