### PR TITLE
fix: fallback to latest Minecraft release correctly

### DIFF
--- a/src/components/Data/RequiresMatcher/RequiresMatcher.ts
+++ b/src/components/Data/RequiresMatcher/RequiresMatcher.ts
@@ -67,10 +67,11 @@ export class RequiresMatcher {
 		const config = this.app.project.config.get()
 
 		this.experimentalGameplay = config.experimentalGameplay ?? {}
+
+		this.latestFormatVersion = latestFormatVersion
 		this.projectTargetVersion =
 			config.targetVersion ?? this.latestFormatVersion
 
-		this.latestFormatVersion = latestFormatVersion
 		this.bpManifest = bpManifest
 		this.isSetup = true
 	}


### PR DESCRIPTION
Currently, projects without a targetVersion fail to load various of our app features correctly because we don't fallback to the latest Minecraft release correctly. This also resulted in users being unable to open the "New File" window within these projects.

Also, maybe this should instead load the current stable release instead, @Joelant05?