### PR TITLE
feat: no mobile toolbar

### DIFF
--- a/src/components/Mixins/AppToolbarHeight.ts
+++ b/src/components/Mixins/AppToolbarHeight.ts
@@ -7,13 +7,13 @@ export const AppToolbarHeightMixin = {
 	computed: {
 		appToolbarHeight() {
 			return `env(titlebar-area-height, ${
-				this.$vuetify.breakpoint.mobile ? 32 : 24
+				this.$vuetify.breakpoint.mobile ? 0 : 24
 			}px)`
 		},
 		appToolbarHeightNumber() {
 			if (this.windowControlsOverlay) return 33
 
-			return this.$vuetify.breakpoint.mobile ? 32 : 24
+			return this.$vuetify.breakpoint.mobile ? 0 : 24
 		},
 	},
 }

--- a/src/components/Sidebar/Button.vue
+++ b/src/components/Sidebar/Button.vue
@@ -139,11 +139,11 @@ export default {
 		},
 	},
 	methods: {
-		onClick() {
+		onClick(event) {
 			if (this.disabled) return
 
 			if (this.alwaysAllowClick || !this.isLoading) {
-				this.$emit('click')
+				this.$emit('click', event)
 
 				// Otherwise the tooltip can get stuck until the user hovers over the button again
 				this.hasClicked = true

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -35,7 +35,6 @@
 				@click="closeSidebar"
 			/>
 			<SidebarButton
-				v-if="isMobile"
 				displayName="actions.name"
 				icon="mdi-menu"
 				@click="showMobileMenu"

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -20,13 +20,20 @@
 			top: appToolbarHeight,
 		}"
 	>
-		<SidebarButton
-			v-if="isMobile"
-			displayName="general.close"
-			icon="mdi-close"
-			color="error"
-			@click="closeSidebar"
-		/>
+		<template v-if="isMobile">
+			<SidebarButton
+				displayName="general.close"
+				icon="mdi-close"
+				color="error"
+				@click="closeSidebar"
+			/>
+			<SidebarButton
+				v-if="isMobile"
+				displayName="actions.name"
+				icon="mdi-menu"
+				@click="showMobileMenu"
+			/>
+		</template>
 
 		<v-list>
 			<SidebarButton
@@ -146,6 +153,9 @@ export default {
 	methods: {
 		closeSidebar() {
 			App.sidebar.isNavigationVisible.value = false
+		},
+		showMobileMenu(event) {
+			App.toolbar.showMobileMenu(event)
 		},
 	},
 }

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -21,6 +21,10 @@
 		}"
 	>
 		<template v-if="isMobile">
+			<div class="d-flex align-center justify-center mt-3 mb-2">
+				<BridgeLogo :height="32" />
+			</div>
+
 			<SidebarButton
 				displayName="general.close"
 				icon="mdi-close"
@@ -86,16 +90,35 @@
 				/>
 			</SidebarButton>
 		</v-list>
+
+		<div v-if="isMobile" class="py-2" />
+
+		<div
+			v-if="isMobile"
+			class="pr-1 font-weight-light"
+			style="
+				position: absolute;
+				bottom: 0;
+				width: 100%;
+				text-align: center;
+				font-size: 14px;
+				z-index: -1;
+			"
+		>
+			v{{ appVersion }}
+		</div>
 	</v-navigation-drawer>
 </template>
 
 <script>
+import BridgeLogo from '/@/components/UIElements/Logo.vue'
 import { settingsState } from '/@/components/Windows/Settings/SettingsState.ts'
 import SidebarButton from './Button.vue'
 import { tasks } from '/@/components/TaskManager/TaskManager.ts'
 import { NotificationStore } from '/@/components/Notifications/state.ts'
 import { AppToolbarHeightMixin } from '/@/components/Mixins/AppToolbarHeight.ts'
 import { App } from '/@/App'
+import { version as appVersion } from '/@/utils/app/version'
 
 export default {
 	name: 'Sidebar',
@@ -105,12 +128,14 @@ export default {
 	},
 	components: {
 		SidebarButton,
+		BridgeLogo,
 	},
 
 	setup() {
 		return {
 			rawSidebarElements: App.sidebar.sortedElements,
 			rawIsNavigationVisible: App.sidebar.isNavigationVisible,
+			appVersion,
 		}
 	},
 	data() {

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -21,8 +21,11 @@
 		}"
 	>
 		<template v-if="isMobile">
-			<div class="d-flex align-center justify-center mt-3 mb-2">
-				<BridgeLogo :height="32" />
+			<div
+				class="d-flex align-center justify-center mt-3 mb-2 mx-1 rounded-lg"
+				v-ripple
+			>
+				<BridgeLogo :height="32" @click.native="openChangelogWindow" />
 			</div>
 
 			<SidebarButton
@@ -90,23 +93,6 @@
 				/>
 			</SidebarButton>
 		</v-list>
-
-		<div v-if="isMobile" class="py-2" />
-
-		<div
-			v-if="isMobile"
-			class="pr-1 font-weight-light"
-			style="
-				position: absolute;
-				bottom: 0;
-				width: 100%;
-				text-align: center;
-				font-size: 14px;
-				z-index: -1;
-			"
-		>
-			v{{ appVersion }}
-		</div>
 	</v-navigation-drawer>
 </template>
 
@@ -181,6 +167,10 @@ export default {
 		},
 		showMobileMenu(event) {
 			App.toolbar.showMobileMenu(event)
+		},
+		async openChangelogWindow() {
+			const app = await App.getApp()
+			await app.windows.changelogWindow.open()
 		},
 	},
 }

--- a/src/components/Toolbar/Main.vue
+++ b/src/components/Toolbar/Main.vue
@@ -1,5 +1,6 @@
 <template>
 	<v-system-bar
+		v-if="!isMobile"
 		color="toolbar"
 		fixed
 		app
@@ -54,13 +55,6 @@
 
 			<!-- App menu buttons -->
 			<v-toolbar-items class="px14-font">
-				<MenuButton
-					v-if="isMobile"
-					displayName="actions.name"
-					displayIcon="mdi-menu"
-					@click="showMobileMenu"
-				/>
-
 				<template v-for="(item, key, i) in toolbar">
 					<MenuButton
 						v-if="item.type !== 'category'"
@@ -179,9 +173,6 @@ export default {
 			if (this.isAnyWindowVisible) return
 
 			CommandBarState.isWindowOpen = true
-		},
-		showMobileMenu(event) {
-			App.toolbar.showMobileMenu(event)
 		},
 	},
 }


### PR DESCRIPTION
## Summary
The toolbar on mobile was pretty useless since the last release because it only showed the "Actions" item and the bridge. logo.
This PR hides the toolbar on mobile and instead integrates the toolbar items into the sidebar freeing up more space on small screens.
![Bildschirmfoto 2022-10-12 um 11 53 27](https://user-images.githubusercontent.com/33347616/195312595-188402c7-3ef9-459f-8c54-03b3cbdd3356.png)

## Open questions: 
- Should we show a bridge. logo within the sidebar? (Yes, above all buttons?)
- Where should we display the bridge. version number? (Bottom of the sidebar?)