### PR TITLE
upd(ProjectChooser): load all projects button now also works for com.mojang projects

### DIFF
--- a/src/components/OutputFolders/ComMojang/ComMojang.ts
+++ b/src/components/OutputFolders/ComMojang/ComMojang.ts
@@ -5,7 +5,6 @@ import { App } from '/@/App'
 import { Signal } from '/@/components/Common/Event/Signal'
 import { InformationWindow } from '/@/components/Windows/Common/Information/InformationWindow'
 import { AnyDirectoryHandle } from '/@/components/FileSystem/Types'
-import { Project } from '/@/components/Projects/Project/Project'
 
 export const comMojangKey = 'comMojangDirectory'
 
@@ -17,9 +16,13 @@ export class ComMojang extends Signal<void> {
 	public readonly setup = new Signal<void>()
 	protected _hasComMojang = false
 	protected _permissionDenied = false
+	protected _hasComMojangHandle = false
 
 	get hasComMojang() {
 		return this._hasComMojang
+	}
+	get hasComMojangHandle() {
+		return this._hasComMojangHandle
 	}
 	get status() {
 		return {
@@ -37,6 +40,8 @@ export class ComMojang extends Signal<void> {
 		const directoryHandle = await get<AnyDirectoryHandle | undefined>(
 			comMojangKey
 		)
+
+		this._hasComMojangHandle = directoryHandle !== undefined
 
 		if (directoryHandle) {
 			await this.requestPermissions(directoryHandle).catch(async () => {

--- a/src/components/Projects/ProjectChooser/ProjectChooser.ts
+++ b/src/components/Projects/ProjectChooser/ProjectChooser.ts
@@ -71,8 +71,11 @@ export class ProjectChooserWindow extends NewBaseWindow {
 		this.state.showLoadAllButton = 'isLoading'
 		const app = await App.getApp()
 
-		const wasSuccessful = await app.setupBridgeFolder()
-		const wasComMojangSuccesful = await app.comMojang.setupComMojang()
+		// Only request permission if the user didn't already grant it
+		const wasSuccessful =
+			app.bridgeFolderSetup.hasFired || (await app.setupBridgeFolder())
+		const wasComMojangSuccesful =
+			app.comMojang.hasFired || (await app.comMojang.setupComMojang())
 
 		if (wasSuccessful || wasComMojangSuccesful) {
 			await this.loadProjects()
@@ -100,7 +103,9 @@ export class ProjectChooserWindow extends NewBaseWindow {
 		this.sidebar.removeElements()
 		const app = await App.getApp()
 
-		this.state.showLoadAllButton = !app.bridgeFolderSetup.hasFired
+		// Show the loadAllButton if the user didn't grant permissions to bridge folder or comMojang folder yet
+		this.state.showLoadAllButton =
+			!app.bridgeFolderSetup.hasFired || !app.comMojang.setup.hasFired
 
 		const projects = await app.projectManager.getProjects()
 		const experimentalToggles = await app.dataLoader.readJSON(

--- a/src/components/Projects/ProjectChooser/ProjectChooser.ts
+++ b/src/components/Projects/ProjectChooser/ProjectChooser.ts
@@ -74,8 +74,10 @@ export class ProjectChooserWindow extends NewBaseWindow {
 		// Only request permission if the user didn't already grant it
 		const wasSuccessful =
 			app.bridgeFolderSetup.hasFired || (await app.setupBridgeFolder())
-		const wasComMojangSuccesful =
-			app.comMojang.hasFired || (await app.comMojang.setupComMojang())
+		// For the com.mojang folder, we additionally check that bridge. already has its handle stored in IDB
+		const wasComMojangSuccesful = app.comMojang.hasComMojangHandle
+			? app.comMojang.hasFired || (await app.comMojang.setupComMojang())
+			: true
 
 		if (wasSuccessful || wasComMojangSuccesful) {
 			await this.loadProjects()
@@ -105,7 +107,8 @@ export class ProjectChooserWindow extends NewBaseWindow {
 
 		// Show the loadAllButton if the user didn't grant permissions to bridge folder or comMojang folder yet
 		this.state.showLoadAllButton =
-			!app.bridgeFolderSetup.hasFired || !app.comMojang.setup.hasFired
+			!app.bridgeFolderSetup.hasFired ||
+			(!app.comMojang.setup.hasFired && app.comMojang.hasComMojangHandle)
 
 		const projects = await app.projectManager.getProjects()
 		const experimentalToggles = await app.dataLoader.readJSON(


### PR DESCRIPTION
Previously, the button did not appear if permissions to the com.mojang folder weren't granted yet