### PR TITLE
upd(ComMojang): remove double prompt

### DIFF
--- a/src/components/OutputFolders/ComMojang/ComMojang.ts
+++ b/src/components/OutputFolders/ComMojang/ComMojang.ts
@@ -96,17 +96,9 @@ export class ComMojang extends Signal<void> {
 	}
 
 	async handleComMojangDrop(directoryHandle: AnyDirectoryHandle) {
-		const confirmWindow = new ConfirmationWindow({
-			description: 'comMojang.folderDropped',
-			confirmText: 'general.yes',
-			cancelText: 'general.no',
-		})
-
 		// User wants to set default com.mojang folder
-		if (await confirmWindow.fired) {
-			await this.set(directoryHandle)
-			await this.app.projectManager.recompileAll()
-		}
+		await this.set(directoryHandle)
+		if (this._hasComMojang) await this.app.projectManager.recompileAll()
 	}
 
 	async unlink() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1009,7 +1009,6 @@
 		}
 	},
 	"comMojang": {
-		"folderDropped": "Do you want to set this folder as your default com.mojang folder?",
 		"title": "Access to folder \"com.mojang\"",
 		"permissionRequest": "bridge. needs access to your \"com.mojang\" folder in order to compile projects to it.",
 		"status": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -901,7 +901,6 @@
 		}
 	},
 	"comMojang": {
-		"folderDropped": "このフォルダーをデフォルトの com.mojang フォルダーとして設定しますか？",
 		"title": "com.mojang フォルダーへのアクセス",
 		"permissionRequest": "プロジェクトをコンパイルするには com.mojang フォルダーにアクセスする必要があります",
 		"status": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1005,7 +1005,6 @@
 		}
 	},
 	"comMojang": {
-		"folderDropped": "Wilt u deze map instellen als uw standaard com.mojang map?",
 		"title": "Toegang tot map \"com.mojang\"",
 		"permissionRequest": "bridge. heeft toegang nodig tot uw \"com.mojang\" map om er projecten naar te kunnen compileren.",
 		"status": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -931,7 +931,6 @@
 		}
 	},
 	"comMojang": {
-		"folderDropped": "你想将此文件夹设置为默认的com.mojang文件夹吗？",
 		"title": "访问文件夹“com.mojang”",
 		"permissionRequest": "bridge.需要访问你的“com.mojang”文件夹才能将项目编译到其中。",
 		"status": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -446,7 +446,6 @@
 		}
 	},
 	"comMojang": {
-		"folderDropped": "是否將這個資料夾設為預設的com.mojang資料夾?",
 		"permissionRequest": "bridge.必須存取你的com.mojang資料夾才能編譯專案。"
 	},
 	"findAndReplace": {


### PR DESCRIPTION
## Summary
Previously, an additional confirmation window popped up after choosing the "Output Folder" option within the InformedChoiceWindow. This window is entirely unnecessary now that the InformedChoiceWindow exists after dropping a folder onto bridge. so we should remove it to reduce friction around setting up the com.mojang folder
