### PR TITLE
feat: auto save setting

### DIFF
--- a/src/components/Editors/Text/TextTab.ts
+++ b/src/components/Editors/Text/TextTab.ts
@@ -121,6 +121,7 @@ export class TextTab extends FileTab {
 		this.disposables.push(
 			this.editorModel?.onDidChangeContent(() => {
 				throttledCacheUpdate(this)
+				this.fileDidChange()
 			})
 		)
 		this.disposables.push(

--- a/src/components/Editors/Text/TextTab.ts
+++ b/src/components/Editors/Text/TextTab.ts
@@ -14,9 +14,6 @@ import { wait } from '/@/utils/wait'
 
 const throttledCacheUpdate = debounce<(tab: TextTab) => Promise<void> | void>(
 	async (tab) => {
-		// Updates the isUnsaved status of the tab
-		tab.updateUnsavedStatus()
-
 		if (!tab.editorModel || tab.editorModel.isDisposed()) return
 
 		const fileContent = tab.editorModel?.getValue()
@@ -78,6 +75,13 @@ export class TextTab extends FileTab {
 		)
 	}
 
+	fileDidChange() {
+		// Updates the isUnsaved status of the tab
+		this.updateUnsavedStatus()
+
+		super.fileDidChange()
+	}
+
 	async onActivate() {
 		if (this.isActive) return
 		this.isActive = true
@@ -132,7 +136,9 @@ export class TextTab extends FileTab {
 
 		this.editorInstance?.layout()
 	}
-	onDeactivate() {
+	async onDeactivate() {
+		await super.onDeactivate()
+
 		// MonacoEditor is defined
 		if (this.tabSystem.hasFired) {
 			const viewState = this.editorInstance.saveViewState()

--- a/src/components/Editors/TreeEditor/Tab.ts
+++ b/src/components/Editors/TreeEditor/Tab.ts
@@ -99,7 +99,9 @@ export class TreeTab extends FileTab {
 	async onActivate() {
 		this.treeEditor.activate()
 	}
-	onDeactivate() {
+	async onDeactivate() {
+		await super.onDeactivate()
+
 		this._treeEditor?.deactivate()
 	}
 

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -73,6 +73,7 @@ export class TreeEditor {
 			this.valueSuggestions = []
 
 			this.parent.updateCache()
+			this.parent.fileDidChange()
 		})
 
 		App.getApp().then(async (app) => {

--- a/src/components/Windows/Settings/setupSettings.ts
+++ b/src/components/Windows/Settings/setupSettings.ts
@@ -395,7 +395,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			description:
 				'windows.settings.editor.bridgePredictions.description',
 			key: 'bridgePredictions',
-			default: false,
+			default: true,
 		})
 	)
 	settings.addControl(

--- a/src/components/Windows/Settings/setupSettings.ts
+++ b/src/components/Windows/Settings/setupSettings.ts
@@ -20,6 +20,8 @@ import { FontSelection } from './Controls/FontSelection'
 import { LocaleManager } from '../../Locales/Manager'
 
 export async function setupSettings(settings: SettingsWindow) {
+	const app = await App.getApp()
+
 	settings.addControl(
 		new ButtonToggle({
 			category: 'appearance',
@@ -29,7 +31,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			options: ['auto', 'dark', 'light'],
 			default: 'auto',
 			onChange: () => {
-				App.getApp().then((app) => app.themeManager.updateTheme())
+				app.themeManager.updateTheme()
 			},
 		})
 	)
@@ -46,7 +48,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			},
 			default: 'bridge.default.dark',
 			onChange: () => {
-				App.getApp().then((app) => app.themeManager.updateTheme())
+				app.themeManager.updateTheme()
 			},
 		})
 	)
@@ -63,7 +65,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			},
 			default: 'bridge.default.light',
 			onChange: () => {
-				App.getApp().then((app) => app.themeManager.updateTheme())
+				app.themeManager.updateTheme()
 			},
 		})
 	)
@@ -82,7 +84,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			},
 			default: 'bridge.noSelection',
 			onChange: () => {
-				App.getApp().then((app) => app.themeManager.updateTheme())
+				app.themeManager.updateTheme()
 			},
 		})
 	)
@@ -101,7 +103,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			},
 			default: 'bridge.noSelection',
 			onChange: () => {
-				App.getApp().then((app) => app.themeManager.updateTheme())
+				app.themeManager.updateTheme()
 			},
 		})
 	)
@@ -143,7 +145,6 @@ export async function setupSettings(settings: SettingsWindow) {
 				'monospace',
 			],
 			onChange: async (val) => {
-				const app = await App.getApp()
 				app.projectManager.updateAllEditorOptions({
 					fontFamily: val,
 				})
@@ -160,7 +161,6 @@ export async function setupSettings(settings: SettingsWindow) {
 			default: '14px',
 			options: ['8px', '10px', '12px', '14px', '16px', '18px', '20px'],
 			onChange: async (val) => {
-				const app = await App.getApp()
 				app.projectManager.updateAllEditorOptions({
 					fontSize: Number(val.replace('px', '')),
 				})
@@ -205,7 +205,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			options: ['tiny', 'small', 'normal', 'large'],
 			default: 'normal',
 			onChange: () => {
-				App.getApp().then((app) => app.windowResize.dispatch())
+				app.windowResize.dispatch()
 			},
 		})
 	)
@@ -313,16 +313,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			default: 'rawText',
 		})
 	)
-	settings.addControl(
-		new Toggle({
-			category: 'editor',
-			name: 'windows.settings.editor.bridgePredictions.name',
-			description:
-				'windows.settings.editor.bridgePredictions.description',
-			key: 'bridgePredictions',
-			default: true,
-		})
-	)
+
 	settings.addControl(
 		new Toggle({
 			category: 'editor',
@@ -332,7 +323,6 @@ export async function setupSettings(settings: SettingsWindow) {
 			key: 'bracketPairColorization',
 			default: false,
 			onChange: async (val) => {
-				const app = await App.getApp()
 				app.projectManager.updateAllEditorOptions({
 					// @ts-expect-error The monaco team did not update the types yet
 					'bracketPairColorization.enabled': val,
@@ -348,7 +338,6 @@ export async function setupSettings(settings: SettingsWindow) {
 			key: 'wordWrap',
 			default: false,
 			onChange: async (val) => {
-				const app = await App.getApp()
 				app.projectManager.updateAllEditorOptions({
 					wordWrap: val ? 'bounded' : 'off',
 				})
@@ -364,7 +353,6 @@ export async function setupSettings(settings: SettingsWindow) {
 			default: '80',
 			options: ['40', '60', '80', '100', '120', '140', '160'],
 			onChange: async (val) => {
-				const app = await App.getApp()
 				app.projectManager.updateAllEditorOptions({
 					wordWrapColumn: Number(val),
 				})
@@ -386,6 +374,27 @@ export async function setupSettings(settings: SettingsWindow) {
 			name: 'windows.settings.editor.keepTabsOpen.name',
 			description: 'windows.settings.editor.keepTabsOpen.description',
 			key: 'keepTabsOpen',
+			default: false,
+		})
+	)
+	settings.addControl(
+		new Toggle({
+			category: 'editor',
+			name: 'windows.settings.editor.autoSaveChanges.name',
+			description: 'windows.settings.editor.autoSaveChanges.description',
+			key: 'autoSaveChanges',
+			default: app.mobile.isCurrentDevice(), // Auto save should be on by default on mobile
+		})
+	)
+
+	// Tree Editor specific settings
+	settings.addControl(
+		new Toggle({
+			category: 'editor',
+			name: 'windows.settings.editor.bridgePredictions.name',
+			description:
+				'windows.settings.editor.bridgePredictions.description',
+			key: 'bridgePredictions',
 			default: false,
 		})
 	)
@@ -471,7 +480,6 @@ export async function setupSettings(settings: SettingsWindow) {
 	)
 
 	// Actions
-	const app = await App.getApp()
 	Object.values(app.actionManager.state).forEach((action) => {
 		if (action.type === 'action')
 			settings.addControl(new ActionViewer(action))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -868,10 +868,7 @@
 					"name": "JSON Editor",
 					"description": "Choose how you want to edit JSON files"
 				},
-				"bridgePredictions": {
-					"name": "bridge. Predictions",
-					"description": "Enable bridge. predictions to let the app intelligently decide whether to add a value or object within bridge.'s tree editor. This simplifies editing JSON significantly"
-				},
+
 				"bracketPairColorization": {
 					"name": "Bracket Pair Colorization",
 					"description": "Give matching brackets an unique color"
@@ -891,6 +888,14 @@
 				"keepTabsOpen": {
 					"name": "Keep Tabs Open",
 					"description": "By default, opening a new tab closes the previously opened tab if it was not interacted with"
+				},
+				"autoSaveChanges": {
+					"name": "Auto Save Changes",
+					"description": "Automatically save changes to files after a short delay"
+				},
+				"bridgePredictions": {
+					"name": "bridge. Predictions",
+					"description": "Enable bridge. predictions to let the app intelligently decide whether to add a value or object within bridge.'s tree editor. This simplifies editing JSON significantly"
 				},
 				"automaticallyOpenTreeNodes": {
 					"name": "Automatically Open Tree Nodes",


### PR DESCRIPTION
## Summary
This implements an auto save setting. When it is enabled, bridge. will automatically save all unsaved changes to files after a 3s delay.
I consider auto saving an important feature to improve the experience using bridge. on mobile as saving files isn't something users are used to do manually on these platforms (that's why the setting is on by default for mobile users). In the past, bridge. not automatically saving changes has been a source of constant confusion for our users.
