### PR TITLE
upd(Extensions): only allow global installations on HomeView

### DIFF
--- a/src/components/Windows/ExtensionStore/ExtensionActions.ts
+++ b/src/components/Windows/ExtensionStore/ExtensionActions.ts
@@ -1,5 +1,6 @@
 import { SimpleAction } from '/@/components/Actions/SimpleAction'
 import { ExtensionViewer } from './ExtensionViewer'
+import { App } from '/@/App'
 
 export const extensionActions = (extension: ExtensionViewer) => [
 	new SimpleAction({
@@ -20,7 +21,10 @@ export const extensionActions = (extension: ExtensionViewer) => [
 			extension.closeActionMenu()
 		},
 	}),
-	!extension.isInstalledLocallyAndGlobally
+	// Only show "Install Local"/"Install Global" action if the extension isn't installed locally and globally yet
+	// ...and if the user is not currently on the "Home View"
+	!extension.isInstalledLocallyAndGlobally &&
+	!App.instance.isNoProjectSelected
 		? new SimpleAction({
 				name: `windows.extensionStore.${
 					extension.isGlobal ? 'installLocal' : 'installGlobal'

--- a/src/components/Windows/ExtensionStore/ExtensionViewer.ts
+++ b/src/components/Windows/ExtensionStore/ExtensionViewer.ts
@@ -66,7 +66,7 @@ export class ExtensionViewer {
 
 	get compilerPlugins() {
 		const ext = this.extension
-		if(ext) return Object.keys(ext.compilerPlugins ?? {})
+		if (ext) return Object.keys(ext.compilerPlugins ?? {})
 
 		return Object.keys(this.config?.compiler?.plugins ?? {})
 	}
@@ -119,8 +119,12 @@ export class ExtensionViewer {
 	}
 
 	async download(isGlobalInstall?: boolean) {
+		const app = await App.getApp()
 		if (isGlobalInstall !== undefined)
 			return this.downloadExtension(isGlobalInstall)
+
+		// If the user is on the HomeView, only allow global extension installations
+		if (app.isNoProjectSelected) return this.downloadExtension(true)
 
 		const installLocationChoiceWindow = new InformedChoiceWindow(
 			'windows.pluginInstallLocation.title'


### PR DESCRIPTION
## Summary
Installing extensions locally to the virtual project that backs the HomeView is not desirable behavior.
