### PR TITLE
fix: import overwrites existing projects

### DIFF
--- a/src/components/Projects/Import/fromBrproject.ts
+++ b/src/components/Projects/Import/fromBrproject.ts
@@ -8,6 +8,7 @@ import { App } from '/@/App'
 import { basename } from '/@/utils/path'
 import { Project } from '../Project/Project'
 import { LocaleManager } from '../../Locales/Manager'
+import { findSuitableFolderName } from '/@/utils/directory/findSuitableName'
 
 export async function importFromBrproject(
 	fileHandle: AnyFileHandle,
@@ -72,10 +73,15 @@ export async function importFromBrproject(
 		}
 	}
 
+	const projectName = await findSuitableFolderName(
+		basename(fileHandle.name, '.brproject'),
+		await fs.getDirectoryHandle('projects')
+	)
+
 	// Get the new project path
 	const importProject =
 		importFrom === 'import'
-			? `projects/${basename(fileHandle.name, '.brproject')}`
+			? `projects/${projectName}`
 			: importFrom.replace('import/', '')
 	// Move imported project to the user's project directory
 	await fs.move(importFrom, importProject)

--- a/src/components/Projects/Import/fromMcaddon.ts
+++ b/src/components/Projects/Import/fromMcaddon.ts
@@ -13,6 +13,7 @@ import { defaultPackPaths } from '../Project/Config'
 import { InformationWindow } from '../../Windows/Common/Information/InformationWindow'
 import { basename } from '/@/utils/path'
 import { getPackId, IManifestModule } from '/@/utils/manifest/getPackId'
+import { findSuitableFolderName } from '/@/utils/directory/findSuitableName'
 
 export async function importFromMcaddon(
 	fileHandle: AnyFileHandle,
@@ -35,9 +36,10 @@ export async function importFromMcaddon(
 		unzipper.createTask(app.taskManager)
 		await unzipper.unzip(data)
 	}
-	const projectName = fileHandle.name
-		.replace('.mcaddon', '')
-		.replace('.zip', '')
+	const projectName = await findSuitableFolderName(
+		fileHandle.name.replace('.mcaddon', '').replace('.zip', ''),
+		await fs.getDirectoryHandle('projects')
+	)
 
 	// Ask user whether they want to save the current project if we are going to delete it later in the import process
 	if (isUsingFileSystemPolyfill.value && !isFirstImport) {

--- a/src/components/Projects/Import/fromMcpack.ts
+++ b/src/components/Projects/Import/fromMcpack.ts
@@ -12,6 +12,7 @@ import { FileSystem } from '/@/components/FileSystem/FileSystem'
 import { defaultPackPaths } from '../Project/Config'
 import { InformationWindow } from '../../Windows/Common/Information/InformationWindow'
 import { getPackId, IManifestModule } from '/@/utils/manifest/getPackId'
+import { findSuitableFolderName } from '/@/utils/directory/findSuitableName'
 
 export async function importFromMcpack(
 	fileHandle: AnyFileHandle,
@@ -34,9 +35,11 @@ export async function importFromMcpack(
 		unzipper.createTask(app.taskManager)
 		await unzipper.unzip(data)
 	}
-	const projectName = fileHandle.name
-		.replace('.mcpack', '')
-		.replace('.zip', '')
+	// Make sure that we don't replace an existing project
+	const projectName = await findSuitableFolderName(
+		fileHandle.name.replace('.mcpack', '').replace('.zip', ''),
+		await fs.getDirectoryHandle('projects')
+	)
 
 	// Ask user whether they want to save the current project if we are going to delete it later in the import process
 	if (isUsingFileSystemPolyfill.value && !isFirstImport) {

--- a/src/components/UIElements/DirectoryViewer/ContextMenu/Actions/Edit/Paste.ts
+++ b/src/components/UIElements/DirectoryViewer/ContextMenu/Actions/Edit/Paste.ts
@@ -1,8 +1,11 @@
 import { DirectoryWrapper } from '../../../DirectoryView/DirectoryWrapper'
 import { clipboard } from './Copy'
+import {
+	findSuitableFileName,
+	findSuitableFolderName,
+} from '/@/utils/directory/findSuitableName'
 import { App } from '/@/App'
 import { AnyHandle } from '/@/components/FileSystem/Types'
-import { basename, extname } from '/@/utils/path'
 
 export const PasteAction = (directoryWrapper: DirectoryWrapper) => ({
 	icon: 'mdi-content-paste',
@@ -21,9 +24,9 @@ export const PasteAction = (directoryWrapper: DirectoryWrapper) => ({
 
 		let newHandle: AnyHandle
 		if (handleToPaste.kind === 'file') {
-			const newName = findSuitableFileName(
+			const newName = await findSuitableFileName(
 				handleToPaste.name,
-				directoryWrapper
+				directoryWrapper.handle
 			)
 
 			newHandle = await directoryWrapper.handle.getFileHandle(newName, {
@@ -33,9 +36,9 @@ export const PasteAction = (directoryWrapper: DirectoryWrapper) => ({
 		} else if (handleToPaste.kind === 'directory') {
 			app.windows.loadingWindow.open()
 
-			const newName = findSuitableFolderName(
+			const newName = await findSuitableFolderName(
 				handleToPaste.name,
-				directoryWrapper
+				directoryWrapper.handle
 			)
 
 			newHandle = await directoryWrapper.handle.getDirectoryHandle(
@@ -55,49 +58,3 @@ export const PasteAction = (directoryWrapper: DirectoryWrapper) => ({
 		return newHandle
 	},
 })
-
-function findSuitableFileName(
-	name: string,
-	directoryWrapper: DirectoryWrapper
-) {
-	const children = directoryWrapper.children.value
-	const fileExt = extname(name)
-	let newName = basename(name, fileExt)
-
-	while (children?.find((child) => child.name === newName + fileExt)) {
-		if (!newName.includes(' copy')) {
-			// 1. Add "copy" to the end of the name
-			newName = `${newName} copy`
-		} else {
-			// 2. Add a number to the end of the name
-			// Get the number from the end of the name
-			const number = parseInt(newName.match(/copy (\d+)/)?.[1] ?? '1')
-			// Remove the last number and add the new one
-			newName = newName.replace(/ \d+$/, '') + ` ${number + 1}`
-		}
-	}
-
-	return newName + fileExt
-}
-function findSuitableFolderName(
-	name: string,
-	directoryWrapper: DirectoryWrapper
-) {
-	const children = directoryWrapper.children.value
-	let newName = name
-
-	while (children?.find((child) => child.name === newName)) {
-		console.log(newName)
-		if (!newName.includes(' copy')) {
-			// 1. Add "copy" to the end of the name
-			newName = `${newName} copy`
-		} else {
-			// 2. Add a number to the end of the name
-			const number = parseInt(newName.match(/copy (\d+)/)?.[1] ?? '1')
-			newName = newName.replace(/ \d+$/, '') + ` ${number + 1}`
-		}
-		console.log('After: ' + newName)
-	}
-
-	return newName
-}

--- a/src/utils/directory/findSuitableName.ts
+++ b/src/utils/directory/findSuitableName.ts
@@ -1,0 +1,47 @@
+import { AnyDirectoryHandle } from '/@/components/FileSystem/Types'
+import { getEntries } from '/@/utils/directory/getEntries'
+import { basename, extname } from '/@/utils/path'
+
+export async function findSuitableFileName(
+	name: string,
+	directorHandle: AnyDirectoryHandle
+) {
+	const children = await getEntries(directorHandle)
+	const fileExt = extname(name)
+	let newName = basename(name, fileExt)
+
+	while (children.find((child) => child.name === newName + fileExt)) {
+		if (!newName.includes(' copy')) {
+			// 1. Add "copy" to the end of the name
+			newName = `${newName} copy`
+		} else {
+			// 2. Add a number to the end of the name
+			// Get the number from the end of the name
+			const number = parseInt(newName.match(/copy (\d+)/)?.[1] ?? '1')
+			// Remove the last number and add the new one
+			newName = newName.replace(/ \d+$/, '') + ` ${number + 1}`
+		}
+	}
+
+	return newName + fileExt
+}
+export async function findSuitableFolderName(
+	name: string,
+	directoryHandle: AnyDirectoryHandle
+) {
+	const children = await getEntries(directoryHandle)
+	let newName = name
+
+	while (children.find((child) => child.name === newName)) {
+		if (!newName.includes(' copy')) {
+			// 1. Add "copy" to the end of the name
+			newName = `${newName} copy`
+		} else {
+			// 2. Add a number to the end of the name
+			const number = parseInt(newName.match(/copy (\d+)/)?.[1] ?? '1')
+			newName = newName.replace(/ \d+$/, '') + ` ${number + 1}`
+		}
+	}
+
+	return newName
+}

--- a/src/utils/directory/getEntries.ts
+++ b/src/utils/directory/getEntries.ts
@@ -1,0 +1,11 @@
+import { AnyDirectoryHandle } from '/@/components/FileSystem/Types'
+
+export async function getEntries(directoryHandle: AnyDirectoryHandle) {
+	const entries = []
+
+	for await (const entry of directoryHandle.values()) {
+		entries.push(entry)
+	}
+
+	return entries
+}


### PR DESCRIPTION
We now use the same logic for finding a free project name that is also used for pasting files and folders.