### PR TITLE
fix: project exports

### DIFF
--- a/src/components/Common/GlobalMutex.ts
+++ b/src/components/Common/GlobalMutex.ts
@@ -1,0 +1,27 @@
+import { Mutex } from './Mutex'
+
+/**
+ * An instance of the Mutex class ensures that calls to specific APIs happen sequentially instead of in parallel.
+ */
+export class GlobalMutex {
+	protected mutexMap = new Map<string, Mutex>()
+
+	async lock(key: string) {
+		let mutex = this.mutexMap.get(key)
+		if (!mutex) {
+			mutex = new Mutex()
+			this.mutexMap.set(key, mutex)
+		}
+
+		await mutex.lock()
+	}
+
+	unlock(key: string) {
+		const mutex = this.mutexMap.get(key)
+		if (!mutex) {
+			throw new Error('Trying to unlock a mutex that does not exist')
+		}
+
+		mutex.unlock()
+	}
+}

--- a/src/components/Common/GlobalMutex.ts
+++ b/src/components/Common/GlobalMutex.ts
@@ -1,11 +1,16 @@
 import { Mutex } from './Mutex'
 
 /**
- * An instance of the Mutex class ensures that calls to specific APIs happen sequentially instead of in parallel.
+ * A global mutex manages multiple different, keyed mutexes.
  */
 export class GlobalMutex {
 	protected mutexMap = new Map<string, Mutex>()
 
+	/**
+	 * Lock the mutex with the given key. Creates the mutex if it does not exist.
+	 *
+	 * @param key Mutex to lock
+	 */
 	async lock(key: string) {
 		let mutex = this.mutexMap.get(key)
 		if (!mutex) {
@@ -16,6 +21,12 @@ export class GlobalMutex {
 		await mutex.lock()
 	}
 
+	/**
+	 * Unlock the mutex with the given key.
+	 *
+	 * @throws If the mutex does not exist.
+	 * @param key
+	 */
 	unlock(key: string) {
 		const mutex = this.mutexMap.get(key)
 		if (!mutex) {

--- a/src/components/Common/Mutex.ts
+++ b/src/components/Common/Mutex.ts
@@ -7,6 +7,11 @@ export class Mutex {
 
 	constructor() {}
 
+	/**
+	 * Lock the mutex. If it is already locked, the function will wait until it is unlocked.
+	 *
+	 * @returns When the mutex is unlocked
+	 */
 	lock() {
 		return new Promise<void>(async (resolve, reject) => {
 			if (this.isLocked) {
@@ -21,6 +26,11 @@ export class Mutex {
 		})
 	}
 
+	/**
+	 * Unlock the mutex.
+	 *
+	 * @throws If the mutex is not locked.
+	 */
 	unlock() {
 		if (!this.isLocked) {
 			throw new Error('Trying to unlock a mutex that is not locked')

--- a/src/components/FileSystem/Virtual/DirectoryHandle.ts
+++ b/src/components/FileSystem/Virtual/DirectoryHandle.ts
@@ -70,10 +70,15 @@ export class VirtualDirectoryHandle extends BaseVirtualHandle {
 
 		this.updateIdb(clearDB)
 	}
-
+	/**
+	 * Acquire exclusive access to this directory
+	 */
 	async lockAccess() {
 		await globalMutex.lock(this.idbKey)
 	}
+	/**
+	 * Release exclusive access to this directory
+	 */
 	unlockAccess() {
 		globalMutex.unlock(this.idbKey)
 	}
@@ -134,6 +139,12 @@ export class VirtualDirectoryHandle extends BaseVirtualHandle {
 		}
 	}
 
+	/**
+	 * @deprecated THIS IS NOT A PUBLIC API
+	 *
+	 * @param childName
+	 * @param lockMutex
+	 */
 	async deleteChild(childName: string, lockMutex = true) {
 		if (lockMutex) await this.lockAccess()
 

--- a/src/components/FileSystem/Virtual/FileHandle.ts
+++ b/src/components/FileSystem/Virtual/FileHandle.ts
@@ -113,6 +113,7 @@ export class VirtualFileHandle extends BaseVirtualHandle {
 		const fileData = await this.loadFromIdb()
 		// console.log(this.path.join('/'), this.fileData, fileData)
 
+		// TODO: Support lastModified timestamp so lightning cache can make use of its optimizations
 		return new File([fileData], this.name)
 	}
 	async createWritable() {


### PR DESCRIPTION
## Summary
This fixes the currently common problems with projects not exporting correctly. The root issue likely caused a bunch of other critical bugs we didn't notice yet.

At least one issue that was likely connected to this problem is #529 but it's also likely that people complaining about the inability to import the ".mcaddon" file into Minecraft experienced this problem in the past (e.g. manifest file not exported).