### PR TITLE
feat: quick exports

### DIFF
--- a/src/components/Compiler/Sidebar/create.ts
+++ b/src/components/Compiler/Sidebar/create.ts
@@ -58,6 +58,13 @@ export function createCompilerSidebar() {
 		displayName: 'sidebar.compiler.name',
 		icon: 'mdi-cogs',
 		disabled: () => App.instance.isNoProjectSelected,
+		/**
+		 * The compiler window is doing more harm than good on mobile (confusion with app settings) so
+		 * we are now disabling it by default.
+		 * Additionally, manual production builds are also pretty much useless as they are internal to bridge. and can only be
+		 * accessed over the "Open Project Folder" button within the project explorer context menu
+		 */
+		defaultVisibility: !App.instance.mobile.isCurrentDevice(),
 		onClick: async () => {
 			const app = await App.getApp()
 			const compilerWindow = app.windows.compilerWindow

--- a/src/components/FileSystem/saveOrDownload.ts
+++ b/src/components/FileSystem/saveOrDownload.ts
@@ -12,7 +12,7 @@ export async function saveOrDownload(
 	fileSystem: FileSystem
 ) {
 	const notification = createNotification({
-		icon: 'mdi-export',
+		icon: 'mdi-download',
 		color: 'success',
 		textColor: 'white',
 		message: 'general.successfulExport.title',

--- a/src/components/Sidebar/SidebarElement.ts
+++ b/src/components/Sidebar/SidebarElement.ts
@@ -12,6 +12,10 @@ export interface ISidebar {
 	displayName?: string
 	group?: string
 	isVisible?: boolean | (() => boolean)
+	/**
+	 * Change the default visibility setting of the sidebar element
+	 */
+	defaultVisibility?: boolean
 	component?: Component
 	sidebarContent?: SidebarContent
 	disabled?: () => boolean
@@ -83,6 +87,9 @@ export class SidebarElement {
 			return this.config.isVisible()
 
 		return this.config.isVisible ?? !!this.isVisibleSetting
+	}
+	get defaultVisibility() {
+		return this.config.defaultVisibility ?? true
 	}
 	get icon() {
 		return this.config.icon

--- a/src/components/Sidebar/setup.ts
+++ b/src/components/Sidebar/setup.ts
@@ -5,6 +5,7 @@ import { SettingsWindow } from '/@/components/Windows/Settings/SettingsWindow'
 import { isUsingFileSystemPolyfill } from '/@/components/FileSystem/Polyfill'
 import { createVirtualProjectWindow } from '/@/components/FileSystem/Virtual/ProjectWindow'
 import { createCompilerSidebar } from '../Compiler/Sidebar/create'
+import { exportAsMcaddon } from '../Projects/Export/AsMcaddon'
 
 export async function setupSidebar() {
 	createSidebar({
@@ -64,6 +65,23 @@ export async function setupSidebar() {
 
 	createCompilerSidebar()
 
+	/**
+	 * Enable one click exports of projects on mobile
+	 * This should help users export projects faster
+	 */
+	createSidebar({
+		id: 'quickExport',
+		displayName: 'sidebar.quickExport.name',
+		icon: 'mdi-export',
+		// Only show quick export option for devices on which com.mojang syncing is not available
+		defaultVisibility: isUsingFileSystemPolyfill.value,
+		disabled: () => App.instance.isNoProjectSelected,
+
+		onClick: () => {
+			exportAsMcaddon()
+		},
+	})
+
 	createSidebar({
 		id: 'extensions',
 		displayName: 'sidebar.extensions.name',
@@ -77,7 +95,8 @@ export async function setupSidebar() {
 	SettingsWindow.loadedSettings.once((settingsState) => {
 		for (const sidebar of Object.values(App.sidebar.elements)) {
 			sidebar.isVisibleSetting =
-				settingsState?.sidebar?.sidebarElements?.[sidebar.uuid] ?? true
+				settingsState?.sidebar?.sidebarElements?.[sidebar.uuid] ??
+				sidebar.defaultVisibility
 		}
 	})
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -471,6 +471,9 @@
 		}
 	},
 	"sidebar": {
+		"quickExport": {
+			"name": "Quick Export"
+		},
 		"openedFolders": {
 			"name": "Opened Folders",
 			"removeFolder": "Remove From View"


### PR DESCRIPTION
## Summary
Disable the compiler window by default on mobile and add a new quick export action to users which cannot use com.mojang syncing


## Motivation
closes #654

