### PR TITLE
fix: turn bridge. predictions off by default

### DIFF
--- a/src/components/Windows/Settings/setupSettings.ts
+++ b/src/components/Windows/Settings/setupSettings.ts
@@ -395,7 +395,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			description:
 				'windows.settings.editor.bridgePredictions.description',
 			key: 'bridgePredictions',
-			default: true,
+			default: false,
 		})
 	)
 	settings.addControl(


### PR DESCRIPTION
## Summary
While bridge. predictions remain broken (#582, #572), disable them by default for users using the tree editor.