### PR TITLE
fix: unlink previous brproject file before export

### DIFF
--- a/src/components/Projects/Export/AsBrproject.ts
+++ b/src/components/Projects/Export/AsBrproject.ts
@@ -7,6 +7,16 @@ export async function exportAsBrproject(name?: string) {
 	const app = App.instance
 	app.windows.loadingWindow.open()
 
+	const savePath = `${app.project.projectPath}/builds/${
+		name ?? app.project.name
+	}.brproject`
+
+	/**
+	 * Make sure to delete old export so the .brproject file doesn't include itself
+	 * This would cause an issue where the ZIP package keeps growing with every export
+	 */
+	await app.fileSystem.unlink(savePath)
+
 	/**
 	 * .brproject files come in two variants:
 	 * - Complete global package including the data/ & extensions/ folder for browsers using the file system polyfill
@@ -17,9 +27,6 @@ export async function exportAsBrproject(name?: string) {
 			? app.fileSystem.baseDirectory
 			: app.project.baseDirectory
 	)
-	const savePath = `${app.project.projectPath}/builds/${
-		name ?? app.project.name
-	}.brproject`
 
 	try {
 		await saveOrDownload(


### PR DESCRIPTION
## Summary
This PR adds an unlink call to delete previously exported ".brproject" packages before doing a new export. This prevents the ".brproject" package growing in size even though the project itself doesn't change