### PR TITLE
fix(bbmodel): animation imports

### DIFF
--- a/src/components/ImportFile/BBModel.ts
+++ b/src/components/ImportFile/BBModel.ts
@@ -494,7 +494,10 @@ export class BBModelImporter extends FileImporter {
 							anim.timeline![this.getTimecodeString(kf.time)] =
 								this.compileBedrockKeyframe(kf, animator)
 						})
-				} else if (animator.type === 'bone') {
+				} else if (
+					animator.type === 'bone' ||
+					animator.type === undefined
+				) {
 					let bone_tag: any = (anim.bones![animator.name] = {})
 					let channels: any = {}
 

--- a/src/components/ImportFile/BBModel.ts
+++ b/src/components/ImportFile/BBModel.ts
@@ -496,7 +496,7 @@ export class BBModelImporter extends FileImporter {
 						})
 				} else if (
 					animator.type === 'bone' ||
-					animator.type === undefined
+					animator.type === undefined // No defined type: Default is type "bone"
 				) {
 					let bone_tag: any = (anim.bones![animator.name] = {})
 					let channels: any = {}


### PR DESCRIPTION
## Summary
Blockbench's bbmodel animation format appears to support omitting `"type": "bone"`. This aligns bridge.'s behavior so we also support importing animators without a set type correctly