### PR TITLE
feat: full screen tab mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,14 @@
 <template>
 	<v-app
+		ref="appContainer"
 		:style="{ fontFamily }"
 		@contextmenu.native="$event.preventDefault()"
 	>
 		<!-- We need access to native menus in order to hide the custom one on MacOS -->
 		<!-- <Toolbar v-if="!isMacOs" /> -->
-		<Toolbar />
+		<Toolbar v-if="!isInFullScreen" />
 
-		<Sidebar app />
+		<Sidebar v-if="!isInFullScreen" app />
 
 		<v-btn
 			v-if="!sidebarNavigationVisible"
@@ -23,7 +24,11 @@
 			<v-icon>mdi-table-column</v-icon>
 		</v-btn>
 
-		<v-main :style="{ 'padding-top': appToolbarHeight }">
+		<v-main
+			:style="{
+				'padding-top': isInFullScreen ? 0 : appToolbarHeight,
+			}"
+		>
 			<WindowRenderer />
 
 			<v-row
@@ -111,6 +116,10 @@ import WelcomeScreen from '/@/components/TabSystem/WelcomeScreen.vue'
 import SidebarContent from './components/Sidebar/Content/Main.vue'
 import { settingsState } from './components/Windows/Settings/SettingsState'
 import { useTabSystem } from './components/Composables/UseTabSystem'
+import {
+	setFullscreenElement,
+	useFullScreen,
+} from './components/TabSystem/TabContextMenu/Fullscreen'
 
 export default {
 	name: 'App',
@@ -119,11 +128,13 @@ export default {
 	setup() {
 		const { tabSystem, tabSystems, shouldRenderWelcomeScreen } =
 			useTabSystem()
+		const { isInFullScreen } = useFullScreen()
 
 		return {
 			tabSystem,
 			tabSystems,
 			shouldRenderWelcomeScreen,
+			isInFullScreen,
 		}
 	},
 
@@ -132,6 +143,8 @@ export default {
 			this.contextMenu = app.contextMenu
 			this.windowSize = app.windowResize.state
 		})
+
+		setFullscreenElement(this.$refs.appContainer.$el)
 	},
 
 	components: {
@@ -156,6 +169,8 @@ export default {
 
 	computed: {
 		isSidebarContentVisible() {
+			if (this.isInFullScreen) return false
+
 			return (
 				this.sidebarNavigationVisible &&
 				App.sidebar.isContentVisible.value

--- a/src/components/CommandBar/CommandBar.vue
+++ b/src/components/CommandBar/CommandBar.vue
@@ -133,9 +133,8 @@ export default {
 					color: packType?.color ?? 'primary',
 
 					onTrigger: async () => {
-						const fileHandle = await project.app.fileSystem.getFileHandle(
-							filePath
-						)
+						const fileHandle =
+							await project.app.fileSystem.getFileHandle(filePath)
 
 						project.openFile(fileHandle)
 					},

--- a/src/components/Mixins/AppToolbarHeight.ts
+++ b/src/components/Mixins/AppToolbarHeight.ts
@@ -1,16 +1,20 @@
 // @ts-nocheck
 
 import { WindowControlsOverlayMixin } from './WindowControlsOverlay'
+import { isInFullScreen } from '/@/components/TabSystem/TabContextMenu/Fullscreen'
 
 export const AppToolbarHeightMixin = {
 	mixins: [WindowControlsOverlayMixin],
 	computed: {
 		appToolbarHeight() {
+			if (isInFullScreen.value) return `0px`
+
 			return `env(titlebar-area-height, ${
 				this.$vuetify.breakpoint.mobile ? 0 : 24
 			}px)`
 		},
 		appToolbarHeightNumber() {
+			if (isInFullScreen.value) return 0
 			if (this.windowControlsOverlay) return 33
 
 			return this.$vuetify.breakpoint.mobile ? 0 : 24

--- a/src/components/TabSystem/CommonTab.ts
+++ b/src/components/TabSystem/CommonTab.ts
@@ -9,6 +9,7 @@ import { AnyFileHandle } from '../FileSystem/Types'
 import { shareFile } from '../StartParams/Action/openRawFile'
 import { getDefaultFileIcon } from '/@/utils/file/getIcon'
 import { settingsState } from '../Windows/Settings/SettingsState'
+import { fullScreenAction } from './TabContextMenu/Fullscreen'
 
 export abstract class Tab<TRestoreData = any> extends Signal<Tab> {
 	abstract component: Vue.Component
@@ -210,6 +211,7 @@ export abstract class Tab<TRestoreData = any> extends Signal<Tab> {
 			additionalItems.push(<const>{ type: 'divider' })
 
 		await showContextMenu(event, [
+			fullScreenAction,
 			...additionalItems,
 			{
 				name: 'actions.closeTab.name',

--- a/src/components/TabSystem/TabActions/ActionBar.vue
+++ b/src/components/TabSystem/TabActions/ActionBar.vue
@@ -1,8 +1,5 @@
 <template>
-	<div
-		class="d-inline-flex mb-1"
-		style="height: 21px; width: 100%; overflow-x: auto; overflow-y: hidden"
-	>
+	<div class="d-inline-flex mb-1 tab-action-bar" style="">
 		<Action
 			v-for="action in actions"
 			:key="action.id"
@@ -22,3 +19,12 @@ export default {
 	},
 }
 </script>
+
+<style scoped>
+.tab-action-bar {
+	height: 21px;
+	width: 100%;
+	overflow-x: auto;
+	overflow-y: hidden;
+}
+</style>

--- a/src/components/TabSystem/TabBar.vue
+++ b/src/components/TabSystem/TabBar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<div class="tab-bar">
 		<Draggable
 			v-if="tabSystem && tabSystem.shouldRender"
 			v-model="tabSystem.tabs.value"
@@ -83,5 +83,8 @@ export default {
 }
 .inactive-action-bar {
 	opacity: 0.5;
+}
+.tab-bar {
+	background: var(--v-background-base);
 }
 </style>

--- a/src/components/TabSystem/TabContextMenu/Fullscreen.ts
+++ b/src/components/TabSystem/TabContextMenu/Fullscreen.ts
@@ -1,0 +1,42 @@
+import { ref } from 'vue'
+
+export const isInFullScreen = ref(false)
+let fullScreenElement: HTMLElement | null = null
+export function setFullscreenElement(el: HTMLElement) {
+	fullScreenElement = el
+}
+export function useFullScreen() {
+	return {
+		isInFullScreen,
+	}
+}
+
+export const fullScreenAction = {
+	icon: 'mdi-fullscreen',
+	name: 'actions.fullscreen.name',
+	description: 'actions.fullscreen.description',
+	onTrigger: () => {
+		if (!fullScreenElement) return
+
+		if (document.fullscreenElement) {
+			document.exitFullscreen()
+		} else {
+			fullScreenElement.requestFullscreen()
+
+			isInFullScreen.value = true
+			const onFullScreenChange = () => {
+				isInFullScreen.value = document.fullscreenElement != null
+
+				// If no longer in fullscreen, remove the event listener
+				if (!isInFullScreen.value) {
+					document.removeEventListener(
+						'fullscreenchange',
+						onFullScreenChange
+					)
+				}
+			}
+			// Listen for fullscreen cancel
+			document.addEventListener('fullscreenchange', onFullScreenChange)
+		}
+	},
+}

--- a/src/components/Toolbar/Category/view.ts
+++ b/src/components/Toolbar/Category/view.ts
@@ -4,6 +4,7 @@ import { FileTab } from '/@/components/TabSystem/FileTab'
 import { ViewCompilerOutput } from '../../UIElements/DirectoryViewer/ContextMenu/Actions/ViewCompilerOutput'
 import { Divider } from '../Divider'
 import { platform } from '/@/utils/os'
+import { fullScreenAction } from '../../TabSystem/TabContextMenu/Fullscreen'
 
 export function setupViewCategory(app: App) {
 	const view = new ToolbarCategory('mdi-eye-outline', 'toolbar.view.name')
@@ -32,6 +33,8 @@ export function setupViewCategory(app: App) {
 	)
 
 	view.addItem(new Divider())
+
+	view.addItem(app.actionManager.create(fullScreenAction))
 
 	view.addItem(
 		app.actionManager.create({

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -128,6 +128,10 @@
 			"name": "Download",
 			"description": "Download this file or folder"
 		},
+		"fullscreen": {
+			"name": "Fullscreen",
+			"description": "Toggle fullscreen mode"
+		},
 		"viewConnectedFiles": {
 			"name": "View Connected Files",
 			"description": "View all files connected to this file"


### PR DESCRIPTION
## Summary
This PR introduces a new fullscreen mode for tabs which hides all UI elements except for the tab bar and the tab contents. This is great for focusing on editing files and can also give embedded third party tools more space to work with

## Motivation and Context
closes #683

## Screenshots (if appropriate):
![Bildschirmfoto 2022-10-28 um 09 49 44](https://user-images.githubusercontent.com/33347616/198557559-01bb4d84-e27c-458e-8c81-455e18e68c6f.png)
![Bildschirmfoto 2022-10-28 um 11 40 46](https://user-images.githubusercontent.com/33347616/198557563-9a33b2ef-2e84-46ec-8236-a832843e47ab.png)
![Bildschirmfoto 2022-10-28 um 11 40 52](https://user-images.githubusercontent.com/33347616/198557564-dc363aa8-7d55-4b64-873c-57dab29096e5.png)
