### PR TITLE
fix: unreliable iframe connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "bridge",
-	"version": "2.3.5",
+	"version": "2.3.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bridge",
-			"version": "2.3.5",
+			"version": "2.3.6",
 			"dependencies": {
 				"@mdi/font": "^6.9.96",
 				"@types/lz-string": "^1.3.34",
 				"bridge-common-utils": "^0.3.3",
-				"bridge-iframe-api": "^0.4.7",
+				"bridge-iframe-api": "^0.4.11",
 				"bridge-js-runtime": "^0.3.6",
 				"bridge-model-viewer": "^0.7.7",
 				"buffer": "^6.0.3",
@@ -2566,9 +2566,9 @@
 			"license": "MIT"
 		},
 		"node_modules/bridge-iframe-api": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/bridge-iframe-api/-/bridge-iframe-api-0.4.7.tgz",
-			"integrity": "sha512-tphsYj61E6nPt5Cnw70IKlmy2IGjvFeYiy3eanCP2IkCJneytJW6vSNbefjq+T0cv8gU8vf5rjFcVlMF8vkAYA=="
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/bridge-iframe-api/-/bridge-iframe-api-0.4.11.tgz",
+			"integrity": "sha512-+gt/4+KkEhtg9vvWI99empq8jOukIAe9nUH9CVdFTXYj4ZLxIqjfBi0XdxyAFKWIapmQDCQA17Wx5d8bBuG4rw=="
 		},
 		"node_modules/bridge-js-runtime": {
 			"version": "0.3.7",
@@ -7736,9 +7736,9 @@
 			}
 		},
 		"bridge-iframe-api": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/bridge-iframe-api/-/bridge-iframe-api-0.4.7.tgz",
-			"integrity": "sha512-tphsYj61E6nPt5Cnw70IKlmy2IGjvFeYiy3eanCP2IkCJneytJW6vSNbefjq+T0cv8gU8vf5rjFcVlMF8vkAYA=="
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/bridge-iframe-api/-/bridge-iframe-api-0.4.11.tgz",
+			"integrity": "sha512-+gt/4+KkEhtg9vvWI99empq8jOukIAe9nUH9CVdFTXYj4ZLxIqjfBi0XdxyAFKWIapmQDCQA17Wx5d8bBuG4rw=="
 		},
 		"bridge-js-runtime": {
 			"version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"@mdi/font": "^6.9.96",
 		"@types/lz-string": "^1.3.34",
 		"bridge-common-utils": "^0.3.3",
-		"bridge-iframe-api": "^0.4.7",
+		"bridge-iframe-api": "^0.4.11",
 		"bridge-js-runtime": "^0.3.6",
 		"bridge-model-viewer": "^0.7.7",
 		"buffer": "^6.0.3",

--- a/src/components/Editors/IframeTab/API/IframeApi.ts
+++ b/src/components/Editors/IframeTab/API/IframeApi.ts
@@ -13,6 +13,7 @@ import { IframeTab } from '../IframeTab'
 import { OpenFileEvent } from './Events/Tab/OpenFile'
 import { openedFileReferenceName } from './Requests/FileSystem/ResolveFileReference'
 import { GetItemPreviewRequest } from './Requests/Project/GetItemPreview'
+import { wait } from '/@/utils/wait'
 
 export class IframeApi {
 	didSetup = false
@@ -41,6 +42,7 @@ export class IframeApi {
 			this._channel = new Channel(this.iframe.contentWindow)
 			this.channelSetup.dispatch()
 
+			await wait(20)
 			await this.channel.open()
 
 			this.loaded.dispatch()


### PR DESCRIPTION
## Summary
Connecting the iframe API was racy before because there was no guarantee for the connection event listener to be setup before the iframe posted its message port. This PR bumps `bridge-iframe-api` to fix this behavior, see https://github.com/bridge-core/bridge-iframe-api/compare/01162de..7786717#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d