### PR TITLE
fix: bridge. offline experience

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,12 +66,12 @@ export default defineConfig({
 			filename: 'service-worker.js',
 			registerType: 'prompt',
 			includeAssets: [
-				'./img/**/*.png',
-				'./img/**/*.svg',
-				'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900',
-				'./packages.zip',
+				'https://fonts.bunny.net/css?family=Roboto:100,300,400,500,700,900',
 			],
 			workbox: {
+				globPatterns: [
+					'**/*.{js,css,html,png,svg,woff2,woff,ttf,wasm,zip}',
+				],
 				maximumFileSizeToCacheInBytes: Number.MAX_SAFE_INTEGER,
 			},
 			manifest: {


### PR DESCRIPTION
## Summary
This PR adjusts our service worker to properly cache icon fonts and wasm files so bridge. works offline correctly.

## Motivation
closes #692
