### PR TITLE
upd: faster directory zipping

### DIFF
--- a/src/components/FileSystem/Zip/ZipDirectory.ts
+++ b/src/components/FileSystem/Zip/ZipDirectory.ts
@@ -1,18 +1,22 @@
 import { zip, Zippable, zipSync } from 'fflate'
 import { AnyDirectoryHandle } from '../Types'
-import { iterateDir } from '/@/utils/iterateDir'
+import { iterateDir, iterateDirParallel } from '/@/utils/iterateDir'
 
 export class ZipDirectory {
 	constructor(protected handle: AnyDirectoryHandle) {}
 
-	async package() {
+	async package(ignoreFolders?: Set<string>) {
 		let directoryContents: Zippable = {}
-		await iterateDir(this.handle, async (fileHandle, filePath) => {
-			const file = await fileHandle.getFile()
-			directoryContents[filePath] = new Uint8Array(
-				await file.arrayBuffer()
-			)
-		})
+		await iterateDirParallel(
+			this.handle,
+			async (fileHandle, filePath) => {
+				const file = await fileHandle.getFile()
+				directoryContents[filePath] = new Uint8Array(
+					await file.arrayBuffer()
+				)
+			},
+			ignoreFolders
+		)
 
 		return new Promise<Uint8Array>((resolve, reject) =>
 			zip(directoryContents, { level: 6 }, (error, data) => {


### PR DESCRIPTION
## Summary
ZIP directories in parallel and allow the package method to specify folders to ignore from the output ZIP