### PR TITLE
upd: omit builds folder

### DIFF
--- a/src/components/FileSystem/Zip/ZipDirectory.ts
+++ b/src/components/FileSystem/Zip/ZipDirectory.ts
@@ -1,18 +1,22 @@
 import { zip, Zippable, zipSync } from 'fflate'
 import { AnyDirectoryHandle } from '../Types'
-import { iterateDir } from '/@/utils/iterateDir'
+import { iterateDir, iterateDirParallel } from '/@/utils/iterateDir'
 
 export class ZipDirectory {
 	constructor(protected handle: AnyDirectoryHandle) {}
 
-	async package() {
+	async package(ignoreFolders?: Set<string>) {
 		let directoryContents: Zippable = {}
-		await iterateDir(this.handle, async (fileHandle, filePath) => {
-			const file = await fileHandle.getFile()
-			directoryContents[filePath] = new Uint8Array(
-				await file.arrayBuffer()
-			)
-		})
+		await iterateDirParallel(
+			this.handle,
+			async (fileHandle, filePath) => {
+				const file = await fileHandle.getFile()
+				directoryContents[filePath] = new Uint8Array(
+					await file.arrayBuffer()
+				)
+			},
+			ignoreFolders
+		)
 
 		return new Promise<Uint8Array>((resolve, reject) =>
 			zip(directoryContents, { level: 6 }, (error, data) => {

--- a/src/components/Projects/Export/AsBrproject.ts
+++ b/src/components/Projects/Export/AsBrproject.ts
@@ -31,7 +31,7 @@ export async function exportAsBrproject(name?: string) {
 	try {
 		await saveOrDownload(
 			savePath,
-			await zipFolder.package(),
+			await zipFolder.package(new Set(['builds'])),
 			app.fileSystem
 		)
 	} catch (err) {

--- a/src/components/Projects/Export/AsBrproject.ts
+++ b/src/components/Projects/Export/AsBrproject.ts
@@ -12,12 +12,6 @@ export async function exportAsBrproject(name?: string) {
 	}.brproject`
 
 	/**
-	 * Make sure to delete old export so the .brproject file doesn't include itself
-	 * This would cause an issue where the ZIP package keeps growing with every export
-	 */
-	await app.fileSystem.unlink(savePath)
-
-	/**
 	 * .brproject files come in two variants:
 	 * - Complete global package including the data/ & extensions/ folder for browsers using the file system polyfill
 	 * - Package only including the project files (no data/ & extensions/) for other browsers


### PR DESCRIPTION
## Summary
The `builds/` folder is producing unnecessary bloat within the brproject package as we currently essentially store the same pack three times (main pack, dev output and dist output).

Depends on #698 