### PR TITLE
feat: streaming unzipping

### DIFF
--- a/src/components/FileSystem/Zip/StreamingUnzipper.ts
+++ b/src/components/FileSystem/Zip/StreamingUnzipper.ts
@@ -1,0 +1,67 @@
+import { AsyncUnzipInflate, Unzip, UnzipFile } from 'fflate'
+import { GenericUnzipper } from './GenericUnzipper'
+import { FileSystem } from '../FileSystem'
+
+export class StreamingUnzipper extends GenericUnzipper<Uint8Array> {
+	unzip(data: Uint8Array) {
+		const fs = new FileSystem(this.directory)
+
+		this.task?.update(0, data.length)
+		let streamedBytes = 0
+		let totalFiles = 0
+		let currentFileCount = 0
+		return new Promise<void>(async (resolve, reject) => {
+			const unzip = new Unzip(async (stream) => {
+				totalFiles++
+				await this.streamFile(fs, stream).catch((err) => reject(err))
+
+				streamedBytes += stream.size ?? 0
+				this.task?.update(streamedBytes)
+
+				currentFileCount++
+				// Is this safe to do? There seems to be no better way to detect that the stream is done processing
+				if (currentFileCount === totalFiles) {
+					this.task?.complete()
+					resolve()
+				}
+			})
+
+			unzip.register(AsyncUnzipInflate)
+			unzip.push(data, true)
+		})
+	}
+
+	async streamFile(fs: FileSystem, stream: UnzipFile) {
+		const fileHandle = await fs.getFileHandle(stream.name, true)
+		const writable = await fileHandle.createWritable()
+		let writeIndex = 0
+		const writePromises: Promise<void>[] = []
+
+		const streamedFile = new Promise<void>((resolve, reject) => {
+			stream.ondata = (err, chunk, final) => {
+				if (err) return reject(err)
+
+				if (chunk) {
+					writePromises.push(
+						writable.write({
+							type: 'write',
+							data: chunk,
+							position: writeIndex,
+						})
+					)
+					writeIndex += chunk.length
+				}
+
+				if (final) {
+					resolve()
+				}
+			}
+		})
+
+		stream.start()
+
+		await streamedFile
+		await Promise.all(writePromises)
+		await writable.close()
+	}
+}

--- a/src/components/Projects/Import/fromBrproject.ts
+++ b/src/components/Projects/Import/fromBrproject.ts
@@ -9,6 +9,7 @@ import { basename } from '/@/utils/path'
 import { Project } from '../Project/Project'
 import { LocaleManager } from '../../Locales/Manager'
 import { findSuitableFolderName } from '/@/utils/directory/findSuitableName'
+import { StreamingUnzipper } from '../../FileSystem/Zip/StreamingUnzipper'
 
 export async function importFromBrproject(
 	fileHandle: AnyFileHandle,
@@ -16,6 +17,7 @@ export async function importFromBrproject(
 ) {
 	const app = await App.getApp()
 	const fs = app.fileSystem
+	await fs.unlink('import')
 	const tmpHandle = await fs.getDirectoryHandle('import', {
 		create: true,
 	})
@@ -24,7 +26,7 @@ export async function importFromBrproject(
 
 	// Unzip .brproject file, do not unzip if already unzipped
 	if (unzip) {
-		const unzipper = new Unzipper(tmpHandle)
+		const unzipper = new StreamingUnzipper(tmpHandle)
 		const file = await fileHandle.getFile()
 		const data = new Uint8Array(await file.arrayBuffer())
 		unzipper.createTask(app.taskManager)


### PR DESCRIPTION
## Summary
Switch the ".brproject" unzipping to use a streaming unzipper to make the process faster and use less memory.
This should fix the issue [described here](https://discord.com/channels/602097536404160523/1035399371333840916/1035399371333840916). If this change is successful, we should further investigate switching ".mcaddon" and ".mcpack" importers over too.