### PR TITLE
fix: make file/folder dropping possible while windows are visible

### DIFF
--- a/src/components/FileDropper/FileDropper.ts
+++ b/src/components/FileDropper/FileDropper.ts
@@ -23,8 +23,6 @@ export class FileDropper {
 		window.addEventListener('drop', (event) => {
 			event.preventDefault()
 
-			if (App.windowState.isAnyWindowVisible.value) return
-
 			this.onDrop([...(event.dataTransfer?.items ?? [])])
 		})
 	}


### PR DESCRIPTION
## Description
Up until now, it wasn't possible to link the com.mojang folder while the linking instructions within the compiler window are visible. This change enables file/folder drop handlers while windows are opened