### PR TITLE
fix(TreeEditor): add enterkeyhint

### DIFF
--- a/src/components/Editors/TreeEditor/Tab.vue
+++ b/src/components/Editors/TreeEditor/Tab.vue
@@ -59,6 +59,7 @@
 				outlined
 				dense
 				hide-details
+				enterkeyhint="enter"
 			>
 				<template v-slot:item="{ item }">
 					<div style="width: 100%" @click="mayTrigger">
@@ -109,6 +110,7 @@
 				outlined
 				dense
 				hide-details
+				enterkeyhint="enter"
 			>
 				<template v-slot:item="{ item }">
 					<div style="width: 100%" @click="mayTrigger">
@@ -150,6 +152,7 @@
 				outlined
 				dense
 				hide-details
+				enterkeyhint="enter"
 			>
 				<template v-slot:item="{ item }">
 					<div style="width: 100%" @click="mayTrigger">


### PR DESCRIPTION
## Description
Some users cannot add arbitrary values within the tree editor because the virtual keyboard doesn't show the correct action button.

## Context:
https://discord.com/channels/602097536404160523/1033955787028049960