### PR TITLE
upd: use last modified timestamp

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -73,8 +73,7 @@ fn main() {
             Ok(())
         })
         .menu(menu)
-        .invoke_handler(tauri::generate_handler![reveal_in_file_explorer])
-        .invoke_handler(tauri::generate_handler![get_file_data])
+        .invoke_handler(tauri::generate_handler![reveal_in_file_explorer, get_file_data])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -26,6 +26,17 @@ async fn reveal_in_file_explorer(path: &str) -> Result<(), String> {
 
     Ok(())
 }
+/**
+ * A function that returns when a file was last modified and its file data
+ */
+#[tauri::command]
+async fn get_file_data(path: &str) -> Result<(u64, Vec<u8>), String> {
+    let metadata = std::fs::metadata(path).expect("Failed to get file metadata");
+    let modified = metadata.modified().expect("Failed to get file modified time").duration_since(std::time::UNIX_EPOCH).expect("Time went backwards").as_secs();
+    let data = std::fs::read(path).expect("Failed to read file");
+
+    Ok((modified, data))
+}
 
 fn main() {
     let mut menu = Menu::os_default(&"bridge. v2");
@@ -63,6 +74,7 @@ fn main() {
         })
         .menu(menu)
         .invoke_handler(tauri::generate_handler![reveal_in_file_explorer])
+        .invoke_handler(tauri::generate_handler![get_file_data])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 

--- a/src/components/FileSystem/Virtual/FileHandle.ts
+++ b/src/components/FileSystem/Virtual/FileHandle.ts
@@ -79,11 +79,7 @@ export class VirtualFileHandle extends BaseVirtualHandle {
 	}
 
 	async getFile() {
-		const fileData = await this.baseStore.readFile(this.idbKey)
-		// console.log(this.path.join('/'), this.fileData, fileData)
-
-		// TODO: Support lastModified timestamp so lightning cache can make use of its optimizations
-		return new File([fileData], this.name)
+		return await this.baseStore.readFile(this.idbKey)
 	}
 	async createWritable() {
 		return new VirtualWritable(this)

--- a/src/components/FileSystem/Virtual/Stores/BaseStore.ts
+++ b/src/components/FileSystem/Virtual/Stores/BaseStore.ts
@@ -57,7 +57,7 @@ export abstract class BaseStore<T = any> {
 	/**
 	 * Read file
 	 */
-	abstract readFile(path: string): Promise<Uint8Array>
+	abstract readFile(path: string): Promise<File>
 
 	/**
 	 * Unlink a file or directory

--- a/src/components/FileSystem/Virtual/Stores/IndexedDb.ts
+++ b/src/components/FileSystem/Virtual/Stores/IndexedDb.ts
@@ -146,14 +146,16 @@ export class IndexedDbStore extends BaseStore<IIndexedDbSerializedData> {
 		}
 
 		let data: Uint8Array
+		let lastModified = Date.now()
 		// Old format where we stored Uint8Array directly
 		if (Array.isArray(rawData)) {
 			data = <Uint8Array>rawData
 		} else {
 			data = (<IFileData>rawData).data ?? new Uint8Array()
+			lastModified = (<IFileData>rawData).lastModified ?? Date.now()
 		}
 
-		return data
+		return new File([data], basename(path), { lastModified })
 	}
 
 	async unlink(path: string) {

--- a/src/components/FileSystem/Virtual/Stores/IndexedDb.ts
+++ b/src/components/FileSystem/Virtual/Stores/IndexedDb.ts
@@ -156,7 +156,7 @@ export class IndexedDbStore extends BaseStore<IIndexedDbSerializedData> {
 		if (rawData instanceof Uint8Array) {
 			data = rawData
 		} else {
-			lastModified = (<IFileData>rawData).lastModified ?? Date.now()
+			lastModified = rawData.lastModified ?? Date.now()
 			data = rawData.data ?? new Uint8Array()
 		}
 


### PR DESCRIPTION
## Summary
Up until now, our file system polyfill did not properly support the `lastModified` timestamp on File objects. (#664)
I've already made some changes to the Memory and IndexedDB backing fs stores to eventually support this with (#740), this PR now enables proper support for the `lastModified` timestamp for all available backing stores of our fs polyfill (TauriFS, IndexedDB and Memory).

Practically, this means that the pack indexer can once again detect when a file did not change and Dash can skip work upon selecting a project if no files changed.

## Motivation
Closes #664