### PR TITLE
fix(IndexedDb): format compat

### DIFF
--- a/src/components/FileSystem/Virtual/Stores/IndexedDb.ts
+++ b/src/components/FileSystem/Virtual/Stores/IndexedDb.ts
@@ -147,10 +147,10 @@ export class IndexedDbStore extends BaseStore<IIndexedDbSerializedData> {
 
 		let data: Uint8Array
 		// Old format where we stored Uint8Array directly
-		if (Array.isArray(rawData)) {
-			data = <Uint8Array>rawData
+		if (rawData instanceof Uint8Array) {
+			data = rawData
 		} else {
-			data = (<IFileData>rawData).data ?? new Uint8Array()
+			data = rawData.data ?? new Uint8Array()
 		}
 
 		return data


### PR DESCRIPTION
## Summary
#740 changed the internal storage format for files and directories. This broke loading of older projects on our file system polyfill platforms (e.g. mobile iOS) with the latest nightly build.

Root issue was that an `Uint8Array` returns `false` when being passed to the `Array.isArray(...)` method. Replacing this condition with an `instanceof` check against the `Uint8Array` class does the trick. (TypeScript actually caught this issue but I thought I was smarter and type casted `rawData` instead. This isn't necessary anymore too)