### PR TITLE
fix: duplicated entries within virtual fs

### DIFF
--- a/src/components/FileSystem/Virtual/Stores/IndexedDb.ts
+++ b/src/components/FileSystem/Virtual/Stores/IndexedDb.ts
@@ -73,7 +73,7 @@ export class IndexedDbStore extends BaseStore<IIndexedDbSerializedData> {
 
 			// Filter out childName from parentChilds
 			parentChilds = parentChilds
-				.filter((child) => typeof child === 'string')
+				.filter((child) => typeof child === 'string') // This filter call is only there to fix already duplicated entries in the database. Can be removed in a future update
 				.filter((child) => child !== childName)
 
 			// Push new child entry


### PR DESCRIPTION
## Summary
Fixes an issue where the virtual file system could save duplicated entries representing the same file or folder. This was caused by our legacy format interfering with the new format (Set deduplication doesn't work when one entry is of type string and the other is an object)