### PR TITLE
feat: fast path for getDirectoryHandle

### DIFF
--- a/src/components/Data/DataLoader.ts
+++ b/src/components/Data/DataLoader.ts
@@ -64,7 +64,7 @@ export class DataLoader extends FileSystem {
 		// Create virtual filesystem
 		this._virtualFileSystem = new VirtualDirectoryHandle(
 			savedAllDataInIdb ? indexedDbStore : new MemoryStore('data-fs'),
-			'bridgeFolder'
+			''
 		)
 		await this._virtualFileSystem.setupDone.fired
 

--- a/src/components/FileSystem/Fast/getDirectoryHandle.ts
+++ b/src/components/FileSystem/Fast/getDirectoryHandle.ts
@@ -1,0 +1,45 @@
+import { IGetHandleConfig } from '../Common'
+import { AnyDirectoryHandle } from '../Types'
+import { VirtualDirectoryHandle } from '../Virtual/DirectoryHandle'
+import { pathFromHandle } from '../Virtual/pathFromHandle'
+
+export async function getDirectoryHandle(
+	baseDirectory: AnyDirectoryHandle,
+	pathArr: string[],
+	{ create, createOnce }: Partial<IGetHandleConfig>
+) {
+	// Cannot apply fast path if baseDirectory is not a virtual directory
+	if (!(baseDirectory instanceof VirtualDirectoryHandle)) return false
+	const baseStore = baseDirectory.getBaseStore()
+
+	// Cannot apply fast path if baseStore is not a TauriFsStore
+	const { TauriFsStore } = await import('../Virtual/Stores/TauriFs')
+	if (!(baseStore instanceof TauriFsStore)) return false
+
+	const { createDir, exists } = await import('@tauri-apps/api/fs')
+	const { join, basename, sep } = await import('@tauri-apps/api/path')
+	const fullPath = await join(await pathFromHandle(baseDirectory), ...pathArr)
+
+	if (create) {
+		await createDir(fullPath, { recursive: !createOnce }).catch((err) => {
+			throw new Error(
+				`Failed to access "${fullPath}": Directory does not exist: ${err}`
+			)
+		})
+	} else if (!(await exists(fullPath))) {
+		throw new Error(
+			`Failed to access "${fullPath}": Directory does not exist`
+		)
+	}
+
+	const basePath = baseStore.getBaseDirectory()
+
+	return new VirtualDirectoryHandle(
+		baseStore,
+		await basename(fullPath),
+		basePath
+			? // pathArr may not contain full path starting from basePath if baseDirectory is not the root directory
+			  fullPath.replace(`${basePath}${sep}`, '').split(sep)
+			: pathArr
+	)
+}

--- a/src/components/FileSystem/Virtual/FileHandle.ts
+++ b/src/components/FileSystem/Virtual/FileHandle.ts
@@ -1,10 +1,11 @@
 import { BaseVirtualHandle } from './Handle'
-import type { VirtualDirectoryHandle } from './DirectoryHandle'
+import { VirtualDirectoryHandle } from './DirectoryHandle'
 import { VirtualWritable, writeMethodSymbol } from './VirtualWritable'
 import { ISerializedFileHandle } from './Comlink'
 import { BaseStore } from './Stores/BaseStore'
 import { deserializeStore } from './Stores/Deserialize'
 import { MemoryStore } from './Stores/Memory'
+import { getParent } from './getParent'
 
 /**
  * A class that implements a virtual file
@@ -66,6 +67,14 @@ export class VirtualFileHandle extends BaseVirtualHandle {
 			data.fileData,
 			data.path
 		)
+	}
+
+	getParent() {
+		// We don't have a parent but we do have a base path -> We can traverse path backwards to create parent handle
+		if (this.parent === null && this.basePath.length > 0) {
+			this.parent = getParent(this.baseStore, this.basePath)
+		}
+		return this.parent
 	}
 
 	override async isSameEntry(other: BaseVirtualHandle): Promise<boolean> {

--- a/src/components/FileSystem/Virtual/Handle.ts
+++ b/src/components/FileSystem/Virtual/Handle.ts
@@ -44,7 +44,9 @@ export abstract class BaseVirtualHandle {
 	}
 
 	protected get path(): string[] {
-		return this.parent ? this.parent.path.concat(this.name) : this.basePath
+		return this.parent
+			? [...this.parent.path.concat(this.name)]
+			: [...this.basePath]
 	}
 	/**
 	 * Returns whether a handle has parent context
@@ -70,9 +72,7 @@ export abstract class BaseVirtualHandle {
 	get name() {
 		return this._name
 	}
-	getParent() {
-		return this.parent
-	}
+	abstract getParent(): VirtualDirectoryHandle | null
 	abstract serialize(): unknown
 
 	async isSameEntry(other: BaseVirtualHandle) {

--- a/src/components/FileSystem/Virtual/getParent.ts
+++ b/src/components/FileSystem/Virtual/getParent.ts
@@ -1,0 +1,11 @@
+import { VirtualDirectoryHandle } from './DirectoryHandle'
+import { BaseStore } from './Stores/BaseStore'
+
+export function getParent(baseStore: BaseStore, basePath: string[]) {
+	return new VirtualDirectoryHandle(
+		baseStore,
+		// Base path always contains itself so new directory handle name is at index - 2
+		basePath.length > 1 ? basePath[basePath.length - 2] : '',
+		basePath.slice(0, -1)
+	)
+}

--- a/src/components/FileSystem/Virtual/pathFromHandle.ts
+++ b/src/components/FileSystem/Virtual/pathFromHandle.ts
@@ -1,12 +1,13 @@
 import { AnyHandle } from '../Types'
 import { BaseVirtualHandle } from './Handle'
-import { TauriFsStore } from './Stores/TauriFs'
 
 export async function pathFromHandle(handle: AnyHandle) {
 	if (!import.meta.env.VITE_IS_TAURI_APP)
 		throw new Error('Can only get path from handle in Tauri builds')
 	if (!(handle instanceof BaseVirtualHandle))
 		throw new Error(`Expected a virtual handle`)
+
+	const { TauriFsStore } = await import('./Stores/TauriFs')
 
 	const baseStore = handle.getBaseStore()
 	if (!(baseStore instanceof TauriFsStore))


### PR DESCRIPTION
## Description
Skip most of the internal implementation of the virtual file system polyfill on Tauri builds to make `getDirectoryHandle` use a constant single fs interaction instead of one fs interaction per path segment.

## Example
Reading a nested texture file within a RP is up to 2x faster now. Exact improvement depends on the path length.

**Edit:** I have also pushed a commit with a fast path for IndexedDB based virtual directory handles now. Results aren't as impressive as I've hoped them to be but I am still seeing a 1s reduction (from 6s) to load a file on my benchmark.