### PR TITLE
feat: fast directory copying

### DIFF
--- a/src-tauri/src/fs_extra.rs
+++ b/src-tauri/src/fs_extra.rs
@@ -1,0 +1,23 @@
+use std::{io, fs};
+use std::path::Path;
+
+pub fn copy_dir_all(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> io::Result<()> {
+    fs::create_dir_all(&dest)?;
+
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+
+        if file_type.is_dir() {
+            copy_dir_all(entry.path(), dest.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dest.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn copy_directory(src: String, dest: String) -> Result<(), String> {
+    copy_dir_all(src, dest).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ use tauri::{Menu, Manager};
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use std::process::Command;
 use window_shadows::set_shadow;
+mod fs_extra;
 
 #[tauri::command]
 async fn reveal_in_file_explorer(path: &str) -> Result<(), String> {
@@ -73,7 +74,7 @@ fn main() {
             Ok(())
         })
         .menu(menu)
-        .invoke_handler(tauri::generate_handler![reveal_in_file_explorer, get_file_data])
+        .invoke_handler(tauri::generate_handler![reveal_in_file_explorer, get_file_data, fs_extra::copy_directory])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 

--- a/src/components/FileSystem/FileSystem.ts
+++ b/src/components/FileSystem/FileSystem.ts
@@ -270,13 +270,11 @@ export class FileSystem extends Signal<void> {
 		const originHandle = await this.getDirectoryHandle(originPath, {
 			create: false,
 		})
-
-		await iterateDirParallel(originHandle, async (fileHandle, filePath) => {
-			await this.copyFileHandle(
-				fileHandle,
-				await this.getFileHandle(join(destPath, filePath), true)
-			)
+		const destHandle = await this.getDirectoryHandle(destPath, {
+			create: true,
 		})
+
+		await this.copyFolderByHandle(originHandle, destHandle)
 	}
 	async copyFolderByHandle(
 		originHandle: AnyDirectoryHandle,

--- a/src/components/FileSystem/FileSystem.ts
+++ b/src/components/FileSystem/FileSystem.ts
@@ -8,6 +8,7 @@ import { AnyDirectoryHandle, AnyFileHandle, AnyHandle } from './Types'
 import { getStorageDirectory } from '/@/utils/getStorageDirectory'
 import { VirtualFileHandle } from './Virtual/FileHandle'
 import { VirtualDirectoryHandle } from './Virtual/DirectoryHandle'
+import { pathFromHandle } from './Virtual/pathFromHandle'
 
 export class FileSystem extends Signal<void> {
 	protected _baseDirectory!: AnyDirectoryHandle
@@ -282,6 +283,21 @@ export class FileSystem extends Signal<void> {
 		destHandle: AnyDirectoryHandle,
 		ignoreFolders?: Set<string>
 	) {
+		// Tauri build: Both handles are virtual -> Elligible for fast path
+		if (
+			import.meta.env.VITE_IS_TAURI_APP &&
+			originHandle instanceof VirtualDirectoryHandle &&
+			destHandle instanceof VirtualDirectoryHandle
+		) {
+			const src = await pathFromHandle(originHandle)
+			const dest = await pathFromHandle(destHandle)
+
+			const { invoke } = await import('@tauri-apps/api')
+			await invoke('copy_directory', { src, dest })
+
+			return
+		}
+
 		const destFs = new FileSystem(destHandle)
 
 		await iterateDirParallel(


### PR DESCRIPTION
## Description
Make copying directories significantly faster on our Tauri builds by calling into Rust.

## Testing
You can test these changes by using the "Import Projects" button. [Comment out the fast path here to test the previous implementation.](https://github.com/bridge-core/editor/pull/761/files#diff-f5dd2dd597f52c18e9dadbee4d919ef36a025ad612608d056b901befa4b8fea9R285-R298) Make sure to select a sufficiently large project.

## Additional Context
I am seeing more than 230x faster directory copies on my benchmarks