### PR TITLE
fix: inactive tab display

### DIFF
--- a/src/components/TabSystem/TabBar.vue
+++ b/src/components/TabSystem/TabBar.vue
@@ -15,7 +15,7 @@
 				v-for="(tab, i) in tabSystem.tabs.value"
 				:key="tab.uuid"
 				:tab="tab"
-				:isActive="tabSystem.isActive"
+				:isActive="tabSystem.isActive.value"
 				:isFirstTab="i === 0"
 			/>
 		</Draggable>

--- a/src/components/TabSystem/TabSystem.ts
+++ b/src/components/TabSystem/TabSystem.ts
@@ -26,7 +26,7 @@ export class TabSystem extends MonacoHolder {
 	protected get tabTypes() {
 		return TabProvider.tabs
 	}
-	protected _isActive = true
+	protected _isActive = ref(true)
 	public readonly openedFiles: OpenedFiles
 
 	get isActive() {
@@ -220,7 +220,7 @@ export class TabSystem extends MonacoHolder {
 	}
 
 	async select(tab?: Tab) {
-		if (this.isActive !== !!tab) this.setActive(!!tab)
+		if (this.isActive.value !== !!tab) this.setActive(!!tab)
 
 		if (this.app.mobile.isCurrentDevice()) App.sidebar.hide()
 		if (tab?.isSelected) return
@@ -307,9 +307,9 @@ export class TabSystem extends MonacoHolder {
 
 	setActive(isActive: boolean, updateProject = true) {
 		if (updateProject) this.project.setActiveTabSystem(this, !isActive)
-		if (isActive === this._isActive) return
+		if (isActive === this._isActive.value) return
 
-		this._isActive = isActive
+		this._isActive.value = isActive
 
 		if (isActive && this._selectedTab && this.project.isActiveProject) {
 			App.eventSystem.dispatch('currentTabSwitched', this._selectedTab)


### PR DESCRIPTION
## Description
The inactive tab system once again displays properly. This was apparently broken for some time now because the _isActive property wasn't reactive.
![Bildschirm­foto 2022-12-07 um 12 09 15](https://user-images.githubusercontent.com/33347616/206164097-bc58b087-1a33-4533-8b3f-23db7f0bfa66.png)

