### PR TITLE
fix: open url

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -195,7 +195,13 @@ export class App {
 		)
 	}
 
-	static openUrl(url: string, id?: string, openInBrowser = false) {
+	static async openUrl(url: string, id?: string, openInBrowser = false) {
+		if (import.meta.env.VITE_IS_TAURI_APP) {
+			const { open } = await import('@tauri-apps/api/shell')
+
+			open(url)
+		}
+
 		if (settingsState?.general?.openLinksInBrowser || openInBrowser)
 			return window.open(url, '_blank')
 		return window.open(url, id, 'toolbar=no,menubar=no,status=no')

--- a/src/components/Extensions/Scripts/Modules/utils.ts
+++ b/src/components/Extensions/Scripts/Modules/utils.ts
@@ -1,5 +1,6 @@
 import { IModuleConfig } from '../types'
+import { App } from '/@/App'
 
 export const UtilsModule = ({}: IModuleConfig) => ({
-	openExternal: (url: string) => window.open(url, '_blank'),
+	openExternal: (url: string) => App.openUrl(url, undefined, true),
 })

--- a/src/components/Toolbar/Category/help.ts
+++ b/src/components/Toolbar/Category/help.ts
@@ -10,9 +10,10 @@ export function setupHelpCategory(app: App) {
 			icon: 'mdi-alert-decagram',
 			description: 'actions.releases.description',
 			onTrigger: () =>
-				window.open(
+				App.openUrl(
 					'https://github.com/bridge-core/editor/releases',
-					'_blank'
+					undefined,
+					true
 				),
 		})
 	)
@@ -22,9 +23,10 @@ export function setupHelpCategory(app: App) {
 			icon: 'mdi-bug-outline',
 			description: 'actions.bugReports.description',
 			onTrigger: () =>
-				window.open(
+				App.openUrl(
 					'https://github.com/bridge-core/editor/issues/new/choose',
-					'_blank'
+					undefined,
+					true
 				),
 		})
 	)
@@ -34,7 +36,7 @@ export function setupHelpCategory(app: App) {
 			icon: 'mdi-twitter',
 			description: 'actions.twitter.description',
 			onTrigger: () =>
-				window.open('https://twitter.com/bridgeIDE', '_blank'),
+				App.openUrl('https://twitter.com/bridgeIDE', undefined, true),
 		})
 	)
 
@@ -48,7 +50,8 @@ export function setupHelpCategory(app: App) {
 			onTrigger: () =>
 				App.openUrl(
 					'https://bridge-core.github.io/extension-docs/',
-					'_blank'
+					undefined,
+					true
 				),
 		})
 	)
@@ -60,7 +63,8 @@ export function setupHelpCategory(app: App) {
 			onTrigger: () =>
 				App.openUrl(
 					'https://bridge-core.github.io/editor-docs/getting-started/',
-					'_blank'
+					undefined,
+					true
 				),
 		})
 	)
@@ -72,7 +76,8 @@ export function setupHelpCategory(app: App) {
 			onTrigger: () =>
 				App.openUrl(
 					'https://bridge-core.github.io/editor-docs/faq/',
-					'_blank'
+					undefined,
+					true
 				),
 		})
 	)

--- a/src/components/Windows/Socials/Main.vue
+++ b/src/components/Windows/Socials/Main.vue
@@ -40,6 +40,7 @@
 <script lang="ts" setup>
 import { useTranslations } from '../../Composables/useTranslations'
 import BaseWindow from '../Layout/BaseWindow.vue'
+import { App } from '/@/App'
 
 const { t } = useTranslations()
 
@@ -50,12 +51,12 @@ function close() {
 	props.window.close()
 }
 function openDiscord() {
-	window.open('https://discord.gg/jj2PmqU', '_blank')
+	App.openUrl('https://discord.gg/jj2PmqU', undefined, true)
 }
 function openTwitter() {
-	window.open('https://twitter.com/bridgeIDE', '_blank')
+	App.openUrl('https://twitter.com/bridgeIDE', undefined, true)
 }
 function openGithub() {
-	window.open('https://github.com/bridge-core', '_blank')
+	App.openUrl('https://github.com/bridge-core', undefined, true)
 }
 </script>


### PR DESCRIPTION
## Description
Opening an URL via `window.open()` is currently broken on MacOS on our native build. This fixes the issue by using Tauri's API for opening URLs instead
