### PR TITLE
fix: remote alert padding

### DIFF
--- a/src/components/TabSystem/WelcomeScreen.vue
+++ b/src/components/TabSystem/WelcomeScreen.vue
@@ -52,7 +52,6 @@ const nativeBuildAvailable = computed(() => {
 })
 
 defineProps({
-	containerPadding: String,
 	height: Number,
 })
 

--- a/src/components/TabSystem/WelcomeScreen.vue
+++ b/src/components/TabSystem/WelcomeScreen.vue
@@ -1,6 +1,10 @@
 <template>
 	<div
-		:class="`pb-16 d-flex flex-column justify-center align-center ${containerPadding}`"
+		:class="{
+			'pb-16 d-flex flex-column justify-center align-center mx-2': true,
+			'ml-0': isContentVisible && !isAttachedRight,
+			'mr-0': isContentVisible && isAttachedRight,
+		}"
 		:style="{ height: height + 'px' }"
 		style="position: relative"
 	>
@@ -38,8 +42,10 @@ import BridgeSheet from '/@/components/UIElements/Sheet.vue'
 import { App } from '/@/App'
 import { useTranslations } from '../Composables/useTranslations'
 import { computed } from 'vue'
+import { useSidebarState } from '../Composables/Sidebar/useSidebarState'
 
 const { t } = useTranslations()
+const { isContentVisible, isAttachedRight } = useSidebarState()
 
 const nativeBuildAvailable = computed(() => {
 	return !import.meta.env.VITE_IS_TAURI_APP && !App.instance.mobile.is.value

--- a/src/components/WelcomeAlert/Alert.vue
+++ b/src/components/WelcomeAlert/Alert.vue
@@ -4,7 +4,7 @@
 		:value="!!title"
 		class="mt-2 mb-8 pa-3"
 		color="purple"
-		:style="`color: ${textColor}; width: calc(100% - 8px); position: absolute; top: 0; left: 0;`"
+		:style="`color: ${textColor}; width: 100%; position: absolute; top: 0; left: 0;`"
 		border="bottom"
 		rounded="lg"
 	>


### PR DESCRIPTION
## Description
Padding for the remote alert wasn't working correctly before this PR. This affected the app states when sidebar content is hidden and when the sidebar nav is hidden (mobile).

### Before
![IMG_BDDE0F0CC672-1](https://user-images.githubusercontent.com/33347616/206852425-107f4322-e1ff-407d-8c39-9a1262e71ad6.jpeg)

### After
![Bildschirm­foto 2022-12-10 um 12 19 24](https://user-images.githubusercontent.com/33347616/206852428-fc3443d8-6723-41af-8d9f-c43a394f2835.png)

