### PR TITLE
fix: reload dash plugins

### DIFF
--- a/src/components/Compiler/Worker/Service.ts
+++ b/src/components/Compiler/Worker/Service.ts
@@ -185,6 +185,8 @@ export class DashService extends EventDispatcher<void> {
 		if (acquireLock) await this.isDashFree.lock()
 		this.dispatch()
 
+		// Reload plugins so we can be sure that e.g. custom commands/components get discovered correctly
+		await this.dash.reload()
 		await this.dash.build()
 
 		if (acquireLock) this.isDashFree.unlock()
@@ -193,6 +195,8 @@ export class DashService extends EventDispatcher<void> {
 		if (acquireLock) await this.isDashFree.lock()
 		this.dispatch()
 
+		// Reload plugins so we can be sure that e.g. custom commands/components get discovered correctly
+		await this.dash.reload()
 		await this.dash.updateFiles(filePaths)
 
 		if (acquireLock) this.isDashFree.unlock()


### PR DESCRIPTION
## Description
This should hopefully fix an issue where Dash didn't compile custom components correctly. Some of our optimizations around disabling specific plugins when certain files are not within the project now require the plugins to be re-evaluated from time to time.

## Motivation
closes #731
