### PR TITLE
fix: various conditions for tauri app

### DIFF
--- a/src/components/Projects/Import/fromBrproject.ts
+++ b/src/components/Projects/Import/fromBrproject.ts
@@ -36,7 +36,10 @@ export async function importFromBrproject(
 	if (!(await fs.fileExists('import/config.json'))) {
 		// The .brproject file contains data/, projects/ & extensions/ folder
 		// We need to change the folder structure to process it correctly
-		if (isUsingFileSystemPolyfill.value) {
+		if (
+			!import.meta.env.VITE_IS_TAURI_APP &&
+			isUsingFileSystemPolyfill.value
+		) {
 			// Only load settings & extension if using the polyfill
 			try {
 				await fs.move('import/data', 'data')
@@ -61,7 +64,11 @@ export async function importFromBrproject(
 	}
 
 	// Ask user whether he wants to save the current project if we are going to delete it later in the import process
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects) {
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	) {
 		const confirmWindow = new ConfirmationWindow({
 			description:
 				'windows.projectChooser.openNewProject.saveCurrentProject',
@@ -91,7 +98,11 @@ export async function importFromBrproject(
 	if (!app.hasNoProjects) currentProject = app.project
 
 	// Remove old project if browser is using fileSystem polyfill
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects)
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	)
 		await app.projectManager.removeProject(currentProject!)
 
 	// Add new project

--- a/src/components/Projects/Import/fromMcaddon.ts
+++ b/src/components/Projects/Import/fromMcaddon.ts
@@ -41,7 +41,11 @@ export async function importFromMcaddon(
 	)
 
 	// Ask user whether they want to save the current project if we are going to delete it later in the import process
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects) {
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	) {
 		const confirmWindow = new ConfirmationWindow({
 			description:
 				'windows.projectChooser.openNewProject.saveCurrentProject',
@@ -126,7 +130,11 @@ export async function importFromMcaddon(
 	await fs.mkdir(`projects/${projectName}/.bridge/compiler`)
 
 	// Remove old project if browser is using fileSystem polyfill
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects)
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	)
 		await app.projectManager.removeProject(app.project)
 
 	// Add new project

--- a/src/components/Projects/Import/fromMcpack.ts
+++ b/src/components/Projects/Import/fromMcpack.ts
@@ -41,7 +41,11 @@ export async function importFromMcpack(
 	)
 
 	// Ask user whether they want to save the current project if we are going to delete it later in the import process
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects) {
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	) {
 		const confirmWindow = new ConfirmationWindow({
 			description:
 				'windows.projectChooser.openNewProject.saveCurrentProject',
@@ -95,7 +99,11 @@ export async function importFromMcpack(
 	await fs.mkdir(`projects/${projectName}/.bridge/extensions`)
 	await fs.mkdir(`projects/${projectName}/.bridge/compiler`)
 
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects)
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	)
 		// Remove old project if browser is using fileSystem polyfill
 		await app.projectManager.removeProject(app.project)
 

--- a/src/components/Toolbar/Category/file.ts
+++ b/src/components/Toolbar/Category/file.ts
@@ -104,7 +104,10 @@ export function setupFileCategory(app: App) {
 		})
 	)
 
-	if (isUsingFileSystemPolyfill.value || isUsingOriginPrivateFs) {
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		(isUsingFileSystemPolyfill.value || isUsingOriginPrivateFs)
+	) {
 		file.addItem(
 			app.actionManager.create({
 				icon: 'mdi-file-download-outline',

--- a/src/components/Toolbar/Category/project.ts
+++ b/src/components/Toolbar/Category/project.ts
@@ -36,7 +36,10 @@ export function setupProjectCategory(app: App) {
 			description: 'windows.projectChooser.description',
 			isDisabled: () => app.hasNoProjects,
 			onTrigger: () => {
-				if (isUsingFileSystemPolyfill.value) {
+				if (
+					!import.meta.env.VITE_IS_TAURI_APP &&
+					isUsingFileSystemPolyfill.value
+				) {
 					createVirtualProjectWindow()
 				} else {
 					App.instance.windows.projectChooser.open()

--- a/src/components/Windows/Settings/setupSettings.ts
+++ b/src/components/Windows/Settings/setupSettings.ts
@@ -295,7 +295,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			default: true,
 		})
 	)
-	if (!isUsingFileSystemPolyfill.value) {
+	if (import.meta.env.VITE_IS_TAURI_APP || !isUsingFileSystemPolyfill.value) {
 		settings.addControl(
 			new Button({
 				category: 'general',


### PR DESCRIPTION
## Description
There were still a lot of references to "isUsingFileSystemPolyfill" that didn't make sense anymore for the native MacOS app leading to unexpected behavior such as prompts for deleting the current project after a project import.