### PR TITLE
fix: project imports

### DIFF
--- a/src/components/Projects/Import/fromBrproject.ts
+++ b/src/components/Projects/Import/fromBrproject.ts
@@ -36,7 +36,10 @@ export async function importFromBrproject(
 	if (!(await fs.fileExists('import/config.json'))) {
 		// The .brproject file contains data/, projects/ & extensions/ folder
 		// We need to change the folder structure to process it correctly
-		if (isUsingFileSystemPolyfill.value) {
+		if (
+			!import.meta.env.VITE_IS_TAURI_APP &&
+			isUsingFileSystemPolyfill.value
+		) {
 			// Only load settings & extension if using the polyfill
 			try {
 				await fs.move('import/data', 'data')
@@ -61,7 +64,11 @@ export async function importFromBrproject(
 	}
 
 	// Ask user whether he wants to save the current project if we are going to delete it later in the import process
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects) {
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	) {
 		const confirmWindow = new ConfirmationWindow({
 			description:
 				'windows.projectChooser.openNewProject.saveCurrentProject',
@@ -91,7 +98,11 @@ export async function importFromBrproject(
 	if (!app.hasNoProjects) currentProject = app.project
 
 	// Remove old project if browser is using fileSystem polyfill
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects)
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	)
 		await app.projectManager.removeProject(currentProject!)
 
 	// Add new project

--- a/src/components/Projects/Import/fromMcaddon.ts
+++ b/src/components/Projects/Import/fromMcaddon.ts
@@ -11,7 +11,7 @@ import { CreateConfig } from '../CreateProject/Files/Config'
 import { FileSystem } from '/@/components/FileSystem/FileSystem'
 import { defaultPackPaths } from '../Project/Config'
 import { InformationWindow } from '../../Windows/Common/Information/InformationWindow'
-import { basename } from '/@/utils/path'
+import { basename, join } from '/@/utils/path'
 import { getPackId, IManifestModule } from '/@/utils/manifest/getPackId'
 import { findSuitableFolderName } from '/@/utils/directory/findSuitableName'
 
@@ -99,10 +99,11 @@ export async function importFromMcaddon(
 
 			packs.push(packId)
 			const packPath = defaultPackPaths[packId]
+
 			// Move the pack to the correct location
 			await fs.move(
 				`import/${pack.name}`,
-				`projects/${projectName}/${packPath}`
+				join('projects', projectName, packPath)
 			)
 		}
 	}

--- a/src/components/Projects/Import/fromMcaddon.ts
+++ b/src/components/Projects/Import/fromMcaddon.ts
@@ -41,7 +41,11 @@ export async function importFromMcaddon(
 	)
 
 	// Ask user whether they want to save the current project if we are going to delete it later in the import process
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects) {
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	) {
 		const confirmWindow = new ConfirmationWindow({
 			description:
 				'windows.projectChooser.openNewProject.saveCurrentProject',
@@ -126,7 +130,11 @@ export async function importFromMcaddon(
 	await fs.mkdir(`projects/${projectName}/.bridge/compiler`)
 
 	// Remove old project if browser is using fileSystem polyfill
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects)
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	)
 		await app.projectManager.removeProject(app.project)
 
 	// Add new project

--- a/src/components/Projects/Import/fromMcpack.ts
+++ b/src/components/Projects/Import/fromMcpack.ts
@@ -41,7 +41,11 @@ export async function importFromMcpack(
 	)
 
 	// Ask user whether they want to save the current project if we are going to delete it later in the import process
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects) {
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	) {
 		const confirmWindow = new ConfirmationWindow({
 			description:
 				'windows.projectChooser.openNewProject.saveCurrentProject',
@@ -95,7 +99,11 @@ export async function importFromMcpack(
 	await fs.mkdir(`projects/${projectName}/.bridge/extensions`)
 	await fs.mkdir(`projects/${projectName}/.bridge/compiler`)
 
-	if (isUsingFileSystemPolyfill.value && !app.hasNoProjects)
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		isUsingFileSystemPolyfill.value &&
+		!app.hasNoProjects
+	)
 		// Remove old project if browser is using fileSystem polyfill
 		await app.projectManager.removeProject(app.project)
 

--- a/src/components/Projects/Import/fromMcpack.ts
+++ b/src/components/Projects/Import/fromMcpack.ts
@@ -13,6 +13,7 @@ import { defaultPackPaths } from '../Project/Config'
 import { InformationWindow } from '../../Windows/Common/Information/InformationWindow'
 import { getPackId, IManifestModule } from '/@/utils/manifest/getPackId'
 import { findSuitableFolderName } from '/@/utils/directory/findSuitableName'
+import { join } from '/@/utils/path'
 
 export async function importFromMcpack(
 	fileHandle: AnyFileHandle,
@@ -74,7 +75,7 @@ export async function importFromMcpack(
 		packs.push(packId)
 		const packPath = defaultPackPaths[packId]
 		// Move the pack to the correct location
-		await fs.move(`import`, `projects/${projectName}/${packPath}`)
+		await fs.move(`import`, join('projects', projectName, packPath))
 	} else {
 		new InformationWindow({
 			description: 'fileDropper.mcaddon.missingManifests',

--- a/src/components/Toolbar/Category/file.ts
+++ b/src/components/Toolbar/Category/file.ts
@@ -104,7 +104,10 @@ export function setupFileCategory(app: App) {
 		})
 	)
 
-	if (isUsingFileSystemPolyfill.value || isUsingOriginPrivateFs) {
+	if (
+		!import.meta.env.VITE_IS_TAURI_APP &&
+		(isUsingFileSystemPolyfill.value || isUsingOriginPrivateFs)
+	) {
 		file.addItem(
 			app.actionManager.create({
 				icon: 'mdi-file-download-outline',

--- a/src/components/Toolbar/Category/project.ts
+++ b/src/components/Toolbar/Category/project.ts
@@ -36,7 +36,10 @@ export function setupProjectCategory(app: App) {
 			description: 'windows.projectChooser.description',
 			isDisabled: () => app.hasNoProjects,
 			onTrigger: () => {
-				if (isUsingFileSystemPolyfill.value) {
+				if (
+					!import.meta.env.VITE_IS_TAURI_APP &&
+					isUsingFileSystemPolyfill.value
+				) {
 					createVirtualProjectWindow()
 				} else {
 					App.instance.windows.projectChooser.open()

--- a/src/components/Windows/Settings/setupSettings.ts
+++ b/src/components/Windows/Settings/setupSettings.ts
@@ -295,7 +295,7 @@ export async function setupSettings(settings: SettingsWindow) {
 			default: true,
 		})
 	)
-	if (!isUsingFileSystemPolyfill.value) {
+	if (import.meta.env.VITE_IS_TAURI_APP || !isUsingFileSystemPolyfill.value) {
 		settings.addControl(
 			new Button({
 				category: 'general',

--- a/src/utils/iterateDir.ts
+++ b/src/utils/iterateDir.ts
@@ -18,7 +18,8 @@ export async function iterateDir(
 			path.length === 0 ? handle.name : `${path}/${handle.name}`
 
 		if (handle.kind === 'file') {
-			if (handle.name[0] === '.') continue
+			if (handle.name[0] === '.' || handle.name.endsWith('.crswap'))
+				continue
 
 			await callback(handle, currentPath, baseDirectory)
 		} else if (
@@ -47,7 +48,8 @@ export async function iterateDirParallel(
 			path.length === 0 ? handle.name : `${path}/${handle.name}`
 
 		if (handle.kind === 'file') {
-			if (handle.name[0] === '.') continue
+			if (handle.name[0] === '.' || handle.name.endsWith('.crswap'))
+				continue
 
 			promises.push(callback(handle, currentPath, baseDirectory))
 		} else if (


### PR DESCRIPTION
## Description
.mcaddon & .mcpack imports where broken because of three reasons:
1) Invalid creation of paths (`projects/myProject/./RP` instead of `projects/myProject/RP`); fixed by using path.join(...) (https://github.com/bridge-core/editor/compare/dev...fix/project-imports?expand=1#diff-949e05b954a361351c598f5d8afbb4bcdd68e9cb63cafbb415a09472117ac807R106)
2) The streaming unzipper tried to write directory paths as files (https://github.com/bridge-core/editor/compare/dev...fix/project-imports?expand=1#diff-a23bb193ef8cc693b41127c17e80b5a3815b9730e55cf1aee08620dad17477ebR28)
3) Chromium's writable close(...) method apparently doesn't properly await the file content being transferred from the ".crswap" file to the actual file. We're doing two things now to prevent an error:
- Do not iterate over ".crswap" files within iterateDir/iterateDirParallel (https://github.com/bridge-core/editor/compare/dev...fix/project-imports?expand=1#diff-7c3198a0c20421ab786361e7aa1cc49ca3b88c7bd87c0f0dd10af90a0be273e0R21)
- Short timeout after finishing the streaming of all files to give Chromium time to catch up (https://github.com/bridge-core/editor/compare/dev...fix/project-imports?expand=1#diff-a23bb193ef8cc693b41127c17e80b5a3815b9730e55cf1aee08620dad17477ebR54)

## Additional Context
Depends on #786