### PR TITLE
feat: add API to open directory picker

### DIFF
--- a/src/components/Extensions/Scripts/Modules/import.ts
+++ b/src/components/Extensions/Scripts/Modules/import.ts
@@ -1,11 +1,16 @@
 import { IModuleConfig } from '../types'
 import { App } from '/@/App'
+import { showFolderPicker } from '/@/components/FileSystem/Pickers/showFolderPicker'
 import { AnyHandle } from '/@/components/FileSystem/Types'
 import { IFolderHandler } from '/@/components/ImportFolder/Manager'
 import {
 	IPluginOpenWithAction,
 	pluginActionStore,
 } from '/@/components/UIElements/DirectoryViewer/ContextMenu/Actions/OpenWith'
+
+interface IPickDirectoryOptions {
+	multiple?: boolean
+}
 
 export const ImportModule = ({ disposables }: IModuleConfig) => ({
 	addFolderImporter: async (handle: IFolderHandler) => {
@@ -29,5 +34,9 @@ export const ImportModule = ({ disposables }: IModuleConfig) => ({
 		disposables.push(disposable)
 
 		return disposable
+	},
+
+	showDirectoryPicker: async (opts: IPickDirectoryOptions) => {
+		await showFolderPicker(opts)
 	},
 })


### PR DESCRIPTION
## Description
Adds an extension API to open a directory picker. In order to fully close the issue linked below, the Vanilla Pack Viewer needs to be updated with a button to open the directory picker.

## Motivation
towards #789
