### PR TITLE
feat: configure bridge folder

### DIFF
--- a/src/components/BottomPanel/Terminal/Terminal.ts
+++ b/src/components/BottomPanel/Terminal/Terminal.ts
@@ -2,10 +2,11 @@ import { markRaw, ref } from 'vue'
 import { invoke } from '@tauri-apps/api/tauri'
 import { App } from '/@/App'
 import { Signal } from '../../Common/Event/Signal'
-import { appLocalDataDir, isAbsolute, join, sep } from '@tauri-apps/api/path'
+import { isAbsolute, join, sep } from '@tauri-apps/api/path'
 import { exists } from '@tauri-apps/api/fs'
 import { listen, Event } from '@tauri-apps/api/event'
 import './Terminal.css'
+import { getBridgeFolderPath } from '/@/utils/getBridgeFolderPath'
 
 type TMessageKind = 'stdout' | 'stderr' | 'stdin'
 
@@ -46,7 +47,7 @@ export class Terminal {
 		const app = await App.getApp()
 		await app.projectManager.projectReady.fired
 
-		this.baseCwd = await join(await appLocalDataDir(), 'bridge')
+		this.baseCwd = await getBridgeFolderPath()
 
 		if (this.cwd.value === '') this.cwd.value = this.baseCwd
 

--- a/src/components/FileSystem/saveOrDownload.ts
+++ b/src/components/FileSystem/saveOrDownload.ts
@@ -30,12 +30,13 @@ export async function saveOrDownload(
 			const app = await App.getApp()
 
 			if (import.meta.env.VITE_IS_TAURI_APP) {
-				const { join, appLocalDataDir } = await import(
-					'@tauri-apps/api/path'
+				const { join } = await import('@tauri-apps/api/path')
+				const { getBridgeFolderPath } = await import(
+					'/@/utils/getBridgeFolderPath'
 				)
 
 				revealInFileExplorer(
-					await join(await appLocalDataDir(), 'bridge', filePath)
+					await join(await getBridgeFolderPath(), filePath)
 				)
 			} else if (
 				app.project.isLocal ||

--- a/src/components/UIElements/DirectoryViewer/ContextMenu/Actions/RevealInFileExplorer.ts
+++ b/src/components/UIElements/DirectoryViewer/ContextMenu/Actions/RevealInFileExplorer.ts
@@ -1,5 +1,6 @@
-import { join, appLocalDataDir } from '@tauri-apps/api/path'
+import { join } from '@tauri-apps/api/path'
 import { BaseWrapper } from '/@/components/UIElements/DirectoryViewer/Common/BaseWrapper'
+import { getBridgeFolderPath } from '/@/utils/getBridgeFolderPath'
 import { revealInFileExplorer } from '/@/utils/revealInFileExplorer'
 
 export const RevealInFileExplorer = (baseWrapper: BaseWrapper<any>) => {
@@ -15,9 +16,7 @@ export const RevealInFileExplorer = (baseWrapper: BaseWrapper<any>) => {
 			let path = baseWrapper.path
 			if (!path) return
 
-			revealInFileExplorer(
-				await join(await appLocalDataDir(), 'bridge', path)
-			)
+			revealInFileExplorer(await join(await getBridgeFolderPath(), path))
 		},
 	}
 }

--- a/src/components/Windows/Settings/SettingsWindow.ts
+++ b/src/components/Windows/Settings/SettingsWindow.ts
@@ -114,6 +114,10 @@ export class SettingsWindow extends NewBaseWindow {
 		}
 	}
 
+	addReloadHint() {
+		this.state.reloadRequired = true
+	}
+
 	async open() {
 		if (this.state.isVisible) return
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -866,9 +866,13 @@
 					"name": "Restore Tabs",
 					"description": "Restore your tabs from when you last used bridge. upon opening the app"
 				},
-				"resetBridgeFolder": {
+				"selectBridgeFolder": {
 					"name": "Select Root Folder",
 					"description": "Choose the main folder bridge. operates on"
+				},
+				"resetBridgeFolder": {
+					"name": "Reset Root Folder",
+					"description": "Reset the app to use bridge. v2's default root folder again"
 				}
 			},
 			"developer": {

--- a/src/utils/getBridgeFolderPath.ts
+++ b/src/utils/getBridgeFolderPath.ts
@@ -1,0 +1,13 @@
+import { appLocalDataDir, join } from '@tauri-apps/api/path'
+import { get } from 'idb-keyval'
+
+export async function getBridgeFolderPath() {
+	if (!import.meta.env.VITE_IS_TAURI_APP)
+		throw new Error(`This function is only available in Tauri apps.`)
+
+	const configuredPath = await get<string | undefined>('bridgeFolderPath')
+	console.log(configuredPath)
+	if (configuredPath) return configuredPath
+
+	return await join(await appLocalDataDir(), 'bridge')
+}

--- a/src/utils/getBridgeFolderPath.ts
+++ b/src/utils/getBridgeFolderPath.ts
@@ -6,7 +6,6 @@ export async function getBridgeFolderPath() {
 		throw new Error(`This function is only available in Tauri apps.`)
 
 	const configuredPath = await get<string | undefined>('bridgeFolderPath')
-	console.log(configuredPath)
 	if (configuredPath) return configuredPath
 
 	return await join(await appLocalDataDir(), 'bridge')

--- a/src/utils/getStorageDirectory.ts
+++ b/src/utils/getStorageDirectory.ts
@@ -22,10 +22,12 @@ export async function getStorageDirectory() {
 		const { TauriFsStore } = await import(
 			'/@/components/FileSystem/Virtual/Stores/TauriFs'
 		)
-		const { join, appLocalDataDir } = await import('@tauri-apps/api/path')
+		const { getBridgeFolderPath } = await import(
+			'/@/utils/getBridgeFolderPath'
+		)
 
 		return new VirtualDirectoryHandle(
-			new TauriFsStore(await join(await appLocalDataDir(), 'bridge')),
+			new TauriFsStore(await getBridgeFolderPath()),
 			'bridge'
 		)
 	}


### PR DESCRIPTION
## Description
Makes the "Select Root Folder" button work on our native build and adds an additional "Reset Root Folder" button on our native build if a different root folder is configured.

## Motivation
closes #788
