### PR TITLE
fix: file dropping

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -70,7 +70,8 @@
 				"title": "",
 				"width": 1200,
 				"titleBarStyle": "Overlay",
-				"acceptFirstMouse": true
+				"acceptFirstMouse": true,
+				"fileDropEnabled": false
 			}
 		]
 	}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -12,7 +12,8 @@
 				"height": 900,
 				"resizable": true,
 				"title": "",
-				"width": 1200
+				"width": 1200,
+				"fileDropEnabled": false
 			}
 		]
 	}


### PR DESCRIPTION
## Description
This fixes dropping files onto bridge. on our native app on MacOS. (Tauri's file drop event seems to disable the webview's native events which our codebase is already using)

 Please confirm that this also fixes the problem on Windows during review.

## Motivation
closes #793
