### PR TITLE
fix: windows file drop

### DIFF
--- a/src/components/FileSystem/Polyfill.ts
+++ b/src/components/FileSystem/Polyfill.ts
@@ -140,7 +140,13 @@ if (isUnsupportedBrowser() || typeof window.showSaveFilePicker !== 'function') {
 	}
 }
 
+/**
+ * In order to support drag and drop of files on our native Windows build,
+ * we need to polyfill the DataTransferItem.getAsFileSystemHandle method
+ * to also use a VirtualFileHandle (just like the base file system)
+ */
 if (
+	import.meta.env.VITE_IS_TAURI_APP ||
 	isUnsupportedBrowser() ||
 	(globalThis.DataTransferItem &&
 		!DataTransferItem.prototype.getAsFileSystemHandle)


### PR DESCRIPTION
## Description
This problem was caused by the native `DataTransferItem.getAsFileSystemHandle` method returning a real directory handle (because Windows' webview supports the file system access API) but our native build using the virtual implementation. We now always overwrite the method on our native app.

## Motivation
closes #798
