### PR TITLE
upd(Dash): faster file reads

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -55,6 +55,7 @@ fn main() {
             fs_extra::reveal_in_file_explorer,
             fs_extra::get_file_data,
             fs_extra::copy_directory,
+            fs_extra::read_file,
             terminal::execute_command,
             terminal::kill_command,
         ])

--- a/src/components/Compiler/Worker/TauriFs.ts
+++ b/src/components/Compiler/Worker/TauriFs.ts
@@ -1,19 +1,18 @@
 import { FileSystem } from 'dash-compiler'
 import { IDirEntry } from 'dash-compiler/dist/FileSystem/FileSystem'
-import { AnyDirectoryHandle } from '../../FileSystem/Types'
 import {
 	writeFile,
 	writeBinaryFile,
 	createDir,
 	removeDir,
 	removeFile,
-	readBinaryFile,
 	readDir,
 	FileEntry,
 	copyFile,
 } from '@tauri-apps/api/fs'
 import { join, basename, dirname, isAbsolute, sep } from '@tauri-apps/api/path'
 import json5 from 'json5'
+import { invoke } from '@tauri-apps/api'
 
 export class TauriBasedDashFileSystem extends FileSystem {
 	constructor(protected baseDirectory?: string) {
@@ -39,7 +38,12 @@ export class TauriBasedDashFileSystem extends FileSystem {
 		)
 	}
 	async readFile(path: string): Promise<File> {
-		const binaryData = await readBinaryFile(await this.resolvePath(path))
+		const resolvedPath = await this.resolvePath(path)
+		const binaryData = new Uint8Array(
+			await invoke<Array<number>>('read_file', {
+				path: resolvedPath,
+			})
+		)
 
 		return new File([binaryData], await basename(path))
 	}


### PR DESCRIPTION
## Description
Tauri's native `readBinaryFile` API seems to be incredible slow. Implementing our own `read_file` command is 5x faster compared to the previous implementation on our native build.

## Motivation
closes #799
