### PR TITLE
feat: faster pack indexing

### DIFF
--- a/src-tauri/src/fs_extra.rs
+++ b/src-tauri/src/fs_extra.rs
@@ -51,23 +51,6 @@ pub async fn reveal_in_file_explorer(path: &str) -> Result<(), String> {
 }
 
 /**
- * A function that returns when a file was last modified and its file data
- */
-#[tauri::command]
-pub async fn get_file_data(path: &str) -> Result<(u64, Vec<u8>), String> {
-    let metadata = fs::metadata(path).expect("Failed to get file metadata");
-    let modified = metadata
-        .modified()
-        .expect("Failed to get file modified time")
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_secs();
-    let data = fs::read(path).expect("Failed to read file");
-
-    Ok((modified, data))
-}
-
-/**
  * A function that returns when a file was last modified
  */
 #[tauri::command]

--- a/src-tauri/src/fs_extra.rs
+++ b/src-tauri/src/fs_extra.rs
@@ -68,6 +68,22 @@ pub async fn get_file_data(path: &str) -> Result<(u64, Vec<u8>), String> {
 }
 
 /**
+ * A function that returns when a file was last modified
+ */
+#[tauri::command]
+pub async fn get_file_last_modified(path: &str) -> Result<u64, String> {
+    let metadata = fs::metadata(path).expect("Failed to get file metadata");
+    let modified = metadata
+        .modified()
+        .expect("Failed to get file modified time")
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs();
+
+    Ok(modified)
+}
+
+/**
  * A faster way to read a binary file compared to Tauri's built-in read_file
  */
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -53,7 +53,6 @@ fn main() {
         .menu(menu)
         .invoke_handler(tauri::generate_handler![
             fs_extra::reveal_in_file_explorer,
-            fs_extra::get_file_data,
             fs_extra::get_file_last_modified,
             fs_extra::copy_directory,
             fs_extra::read_file,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -55,6 +55,7 @@ fn main() {
             fs_extra::reveal_in_file_explorer,
             fs_extra::get_file_data,
             fs_extra::copy_directory,
+            fs_extra::read_file,
             terminal::execute_command,
             terminal::kill_command,
         ])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,6 +54,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             fs_extra::reveal_in_file_explorer,
             fs_extra::get_file_data,
+            fs_extra::get_file_last_modified,
             fs_extra::copy_directory,
             fs_extra::read_file,
             terminal::execute_command,

--- a/src/components/Compiler/Worker/TauriFs.ts
+++ b/src/components/Compiler/Worker/TauriFs.ts
@@ -1,19 +1,18 @@
 import { FileSystem } from 'dash-compiler'
 import { IDirEntry } from 'dash-compiler/dist/FileSystem/FileSystem'
-import { AnyDirectoryHandle } from '../../FileSystem/Types'
 import {
 	writeFile,
 	writeBinaryFile,
 	createDir,
 	removeDir,
 	removeFile,
-	readBinaryFile,
 	readDir,
 	FileEntry,
 	copyFile,
 } from '@tauri-apps/api/fs'
 import { join, basename, dirname, isAbsolute, sep } from '@tauri-apps/api/path'
 import json5 from 'json5'
+import { invoke } from '@tauri-apps/api'
 
 export class TauriBasedDashFileSystem extends FileSystem {
 	constructor(protected baseDirectory?: string) {
@@ -39,7 +38,12 @@ export class TauriBasedDashFileSystem extends FileSystem {
 		)
 	}
 	async readFile(path: string): Promise<File> {
-		const binaryData = await readBinaryFile(await this.resolvePath(path))
+		const resolvedPath = await this.resolvePath(path)
+		const binaryData = new Uint8Array(
+			await invoke<Array<number>>('read_file', {
+				path: resolvedPath,
+			})
+		)
 
 		return new File([binaryData], await basename(path))
 	}

--- a/src/components/FileSystem/Virtual/File.ts
+++ b/src/components/FileSystem/Virtual/File.ts
@@ -1,0 +1,60 @@
+import { BaseStore } from './Stores/BaseStore'
+
+const textDecoder = new TextDecoder()
+
+export class VirtualFile {
+	constructor(
+		protected baseStore: BaseStore,
+		protected readonly path: string,
+		public readonly lastModified: number
+	) {}
+
+	static async for(baseStore: BaseStore, path: string): Promise<File> {
+		const lastModified = await baseStore.lastModified(path)
+
+		return new VirtualFile(baseStore, path, lastModified)
+	}
+
+	get size(): number {
+		throw new Error('Not implemented')
+	}
+	get type(): string {
+		throw new Error('Not implemented')
+	}
+	get webkitRelativePath(): string {
+		throw new Error('Not implemented')
+	}
+	slice(): VirtualFile {
+		throw new Error('Not implemented')
+	}
+
+	get name() {
+		return this.path.split('/').pop()!
+	}
+
+	async arrayBuffer() {
+		return typedArrayToBuffer(await this.baseStore.read(this.path))
+	}
+
+	async text() {
+		return textDecoder.decode(await this.arrayBuffer())
+	}
+
+	stream() {
+		return new ReadableStream({
+			start: async (controller) => {
+				const arrayBuffer = await this.arrayBuffer()
+
+				controller.enqueue(arrayBuffer)
+				controller.close()
+			},
+		})
+	}
+}
+
+function typedArrayToBuffer(array: Uint8Array): ArrayBuffer {
+	return array.buffer.slice(
+		array.byteOffset,
+		array.byteLength + array.byteOffset
+	)
+}

--- a/src/components/FileSystem/Virtual/Stores/BaseStore.ts
+++ b/src/components/FileSystem/Virtual/Stores/BaseStore.ts
@@ -60,6 +60,21 @@ export abstract class BaseStore<T = any> {
 	abstract readFile(path: string): Promise<File>
 
 	/**
+	 * Return when a file was last modified
+	 */
+	lastModified(path: string) {
+		return this.readFile(path).then((file) => file.lastModified)
+	}
+	/**
+	 * Return the content of a file as a Uint8Array
+	 */
+	read(path: string) {
+		return this.readFile(path)
+			.then((file) => file.arrayBuffer())
+			.then((buffer) => new Uint8Array(buffer))
+	}
+
+	/**
 	 * Unlink a file or directory
 	 */
 	abstract unlink(path: string): Promise<void>


### PR DESCRIPTION
## Description
Makes pack indexing faster by switching to a custom "File" implementation. This new class defers reading file content until `file.arrayBuffer()`, `file.text()` & friends are called and we only read the last modified timestamp ahead of time.

## Additional Context
Depends on #803