### PR TITLE
fix: error upon opening image files

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -126,6 +126,7 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "discord-rich-presence",
+ "mime_guess",
  "serde",
  "serde_json",
  "tauri",
@@ -1495,6 +1496,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -3181,6 +3198,15 @@ name = "ucd-trie"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ discord-rich-presence = "0.2.3"
 chrono = "0.4.23"
 window-shadows = "0.2.0"
 tokio = { version = "1.23", features = ["process", "io-util", "sync"] }
+mime_guess = "2.0.4"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/fs_extra.rs
+++ b/src-tauri/src/fs_extra.rs
@@ -54,8 +54,8 @@ pub async fn reveal_in_file_explorer(path: &str) -> Result<(), String> {
  * A function that returns when a file was last modified
  */
 #[tauri::command]
-pub async fn get_file_last_modified(path: &str) -> Result<u64, String> {
-    let metadata = fs::metadata(path).expect("Failed to get file metadata");
+pub async fn get_file_metadata(path: &str) -> Result<(u64, u64, String), String> {
+    let metadata = fs::metadata(path).expect(&format!("Failed to get file metadata for {}", path));
     let modified = metadata
         .modified()
         .expect("Failed to get file modified time")
@@ -63,7 +63,11 @@ pub async fn get_file_last_modified(path: &str) -> Result<u64, String> {
         .expect("Time went backwards")
         .as_secs();
 
-    Ok(modified)
+    let size = metadata.len();
+    let mime_guess = mime_guess::from_path(&path).first_or_text_plain();
+    let mime_type = mime_guess.to_string();
+
+    Ok((size, modified, mime_type))
 }
 
 /**
@@ -86,4 +90,3 @@ pub async fn read_file(path: &str) -> Result<Vec<u8>, String> {
 
     Ok(contents)
 }
-

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -53,7 +53,7 @@ fn main() {
         .menu(menu)
         .invoke_handler(tauri::generate_handler![
             fs_extra::reveal_in_file_explorer,
-            fs_extra::get_file_last_modified,
+            fs_extra::get_file_metadata,
             fs_extra::copy_directory,
             fs_extra::read_file,
             terminal::execute_command,

--- a/src/components/FileSystem/Virtual/Stores/BaseStore.ts
+++ b/src/components/FileSystem/Virtual/Stores/BaseStore.ts
@@ -60,10 +60,14 @@ export abstract class BaseStore<T = any> {
 	abstract readFile(path: string): Promise<File>
 
 	/**
-	 * Return when a file was last modified
+	 * Return when a file was last modified and its size
+	 *
+	 * @returns [size, lastModified]
 	 */
-	lastModified(path: string) {
-		return this.readFile(path).then((file) => file.lastModified)
+	metadata(path: string) {
+		return this.readFile(path).then(
+			(file) => <const>[file.size, file.lastModified, file.type]
+		)
 	}
 	/**
 	 * Return the content of a file as a Uint8Array

--- a/src/components/FileSystem/Virtual/Stores/TauriFs.ts
+++ b/src/components/FileSystem/Virtual/Stores/TauriFs.ts
@@ -80,10 +80,13 @@ export class TauriFsStore extends BaseStore<ITauriFsSerializedData> {
 		return await VirtualFile.for(this, path)
 	}
 
-	async lastModified(path: string) {
-		return (await invoke('get_file_last_modified', {
-			path: await this.resolvePath(path),
-		})) as number
+	async metadata(path: string) {
+		return await invoke<readonly [number, number, string]>(
+			'get_file_metadata',
+			{
+				path: await this.resolvePath(path),
+			}
+		)
 	}
 
 	async read(path: string) {

--- a/src/utils/loadAsDataUrl.ts
+++ b/src/utils/loadAsDataUrl.ts
@@ -1,5 +1,6 @@
 import { FileSystem } from '../components/FileSystem/FileSystem'
 import { AnyFileHandle } from '../components/FileSystem/Types'
+import { VirtualFile } from '../components/FileSystem/Virtual/File'
 import { App } from '/@/App'
 
 export async function loadAsDataURL(filePath: string, fileSystem?: FileSystem) {
@@ -19,7 +20,9 @@ export async function loadAsDataURL(filePath: string, fileSystem?: FileSystem) {
 				resolve(<string>reader.result)
 			})
 			reader.addEventListener('error', reject)
-			reader.readAsDataURL(file)
+			reader.readAsDataURL(
+				file instanceof VirtualFile ? await file.toBlob() : file
+			)
 		} catch {
 			reject(`File does not exist: "${filePath}"`)
 		}
@@ -37,7 +40,10 @@ export function loadHandleAsDataURL(fileHandle: AnyFileHandle) {
 				resolve(<string>reader.result)
 			})
 			reader.addEventListener('error', reject)
-			reader.readAsDataURL(file)
+
+			reader.readAsDataURL(
+				file instanceof VirtualFile ? await file.toBlob() : file
+			)
 		} catch {
 			reject(`File does not exist: "${fileHandle.name}"`)
 		}


### PR DESCRIPTION
## Description
Main issue here was that the web's native `readAsDataUrl()` reader API didn't properly call into our custom VirtualFile class. There's now a `toBlob()` method on our VirtualFile which we can call before passing the virtual file into web APIs. I've also implemented `file.size` & `file.type` to make our implementation (almost) complete

## Motivation
closes #813

