### PR TITLE
fix: virtual files

### DIFF
--- a/src/components/BedrockWorlds/BlockLibrary/BlockLibrary.ts
+++ b/src/components/BedrockWorlds/BlockLibrary/BlockLibrary.ts
@@ -53,10 +53,12 @@ export class BlockLibrary {
 	async setup() {
 		if (!this.dataLoader.hasFired) await this.dataLoader.loadData()
 
+		const file = await this.dataLoader.readFile(
+			'data/packages/minecraftBedrock/vanilla/missing_tile.png'
+		)
+
 		this._missingTexture = await createImageBitmap(
-			await this.dataLoader.readFile(
-				'data/packages/minecraftBedrock/vanilla/missing_tile.png'
-			)
+			file.isVirtual ? await file.toBlobFile() : file
 		)
 
 		const blocksJson = Object.assign(
@@ -160,8 +162,8 @@ export class BlockLibrary {
 				blockData.faces[dir as TDirection] = {
 					...blockData.faces[dir as TDirection],
 					uvOffset: [x, y],
-					texturePath: blockData.faces[dir as TDirection]
-						?.texturePath!,
+					texturePath:
+						blockData.faces[dir as TDirection]?.texturePath!,
 				}
 				currentUVOffset++
 			}

--- a/src/components/BedrockWorlds/BlockLibrary/loadImage.ts
+++ b/src/components/BedrockWorlds/BlockLibrary/loadImage.ts
@@ -11,5 +11,9 @@ export async function loadImage(fileSystem: FileSystem, filePath: string) {
 
 	if (!realPath) return null
 
-	return await createImageBitmap(await fileSystem.readFile(realPath))
+	const file = await fileSystem.readFile(realPath)
+
+	return await createImageBitmap(
+		file.isVirtual ? await file.toBlobFile() : file
+	)
 }

--- a/src/components/Compiler/Worker/FileSystem.ts
+++ b/src/components/Compiler/Worker/FileSystem.ts
@@ -21,8 +21,9 @@ export class DashFileSystem extends FileSystem {
 	async writeJson(path: string, content: any, beautify?: boolean) {
 		await this.internalFs.writeJSON(path, content, beautify)
 	}
-	readFile(path: string): Promise<File> {
-		return this.internalFs.readFile(path)
+	async readFile(path: string): Promise<File> {
+		const file = await this.internalFs.readFile(path)
+		return file.isVirtual ? await file.toBlobFile() : file
 	}
 	async writeFile(path: string, content: string | Uint8Array) {
 		await this.internalFs.writeFile(path, content)

--- a/src/components/Compiler/Worker/Plugins/CustomComponent/ComponentSchemas.ts
+++ b/src/components/Compiler/Worker/Plugins/CustomComponent/ComponentSchemas.ts
@@ -4,6 +4,7 @@ import { DashService } from '../../Service'
 import { App } from '/@/App'
 import { JsRuntime } from '/@/components/Extensions/Scripts/JsRuntime'
 import { AnyDirectoryHandle } from '/@/components/FileSystem/Types'
+import { VirtualFile } from '/@/components/FileSystem/Virtual/File'
 import { Project } from '/@/components/Projects/Project/Project'
 import { IDisposable } from '/@/types/disposable'
 import { iterateDir, iterateDirParallel } from '/@/utils/iterateDir'
@@ -149,7 +150,7 @@ export class ComponentSchemas {
 		jsRuntime: JsRuntime,
 		fileType: TComponentFileType,
 		filePath: string,
-		file: File,
+		file: File | VirtualFile,
 		v1CompatMode: boolean
 	) {
 		let fileContent = new Uint8Array(await file.arrayBuffer())

--- a/src/components/Editors/HTMLPreview/HTMLPreview.ts
+++ b/src/components/Editors/HTMLPreview/HTMLPreview.ts
@@ -6,6 +6,7 @@ import { Tab } from '../../TabSystem/CommonTab'
 import { AnyFileHandle } from '../../FileSystem/Types'
 import { iframeApiVersion } from '/@/utils/app/iframeApiVersion'
 import { translate } from '../../Locales/Manager'
+import { VirtualFile } from '../../FileSystem/Virtual/File'
 
 export class HTMLPreviewTab extends IframeTab {
 	public rawHtml = ''
@@ -133,7 +134,7 @@ export class HTMLPreviewTab extends IframeTab {
 		this.api.trigger('loadScrollPosition', this.scrollY)
 	}
 
-	async load(file?: File) {
+	async load(file?: File | VirtualFile) {
 		if (!file) file = await this.fileHandle.getFile()
 		this.rawHtml = await file.text()
 

--- a/src/components/Extensions/Scripts/JsRuntime.ts
+++ b/src/components/Extensions/Scripts/JsRuntime.ts
@@ -6,7 +6,9 @@ export class JsRuntime extends Runtime {
 	async readFile(filePath: string) {
 		const app = await App.getApp()
 
-		const file = await app.fileSystem.readFile(filePath)
+		// Convince TypeScript that this is a real "File" and not a "VirtualFile"
+		// Because our VirtualFile implements all File methods the JS runtime needs
+		const file = <File>await app.fileSystem.readFile(filePath)
 
 		return file
 	}

--- a/src/components/FileSystem/FileSystem.ts
+++ b/src/components/FileSystem/FileSystem.ts
@@ -294,7 +294,11 @@ export class FileSystem extends Signal<void> {
 		originHandle: AnyFileHandle,
 		destHandle: AnyFileHandle
 	) {
-		await this.write(destHandle, await originHandle.getFile())
+		const file = await originHandle.getFile()
+		await this.write(
+			destHandle,
+			file.isVirtual ? await file.toBlobFile() : file
+		)
 
 		return destHandle
 	}
@@ -353,7 +357,9 @@ export class FileSystem extends Signal<void> {
 					resolve(<string>reader.result)
 				})
 				reader.addEventListener('error', reject)
-				reader.readAsDataURL(file)
+				reader.readAsDataURL(
+					file.isVirtual ? await file.toBlobFile() : file
+				)
 			} catch {
 				reject(`File does not exist: "${fileHandle.name}"`)
 			}

--- a/src/components/FileSystem/FileWatcher.ts
+++ b/src/components/FileSystem/FileWatcher.ts
@@ -2,6 +2,7 @@ import { EventDispatcher } from '/@/components/Common/Event/EventDispatcher'
 import { App } from '/@/App'
 import { Signal } from '/@/components/Common/Event/Signal'
 import { IDisposable } from '/@/types/disposable'
+import { VirtualFile } from './Virtual/File'
 
 export class FileWatcher extends EventDispatcher<File> {
 	protected fileContent: any
@@ -20,7 +21,7 @@ export class FileWatcher extends EventDispatcher<File> {
 		})
 	}
 
-	async setup(file: File) {}
+	async setup(file: File | VirtualFile) {}
 
 	async activate() {
 		if (this.disposable !== undefined) return
@@ -30,7 +31,7 @@ export class FileWatcher extends EventDispatcher<File> {
 			(file) => this.onFileChange(file)
 		)
 	}
-	async requestFile(file: File) {
+	async requestFile(file: File | VirtualFile) {
 		await this.onFileChange(file)
 
 		return new Promise<File>((resolve) => {
@@ -38,14 +39,12 @@ export class FileWatcher extends EventDispatcher<File> {
 		})
 	}
 
-	async compileFile(file: File) {
-		const [
-			dependencies,
-			compiled,
-		] = await this.app.project.compilerService.compileFile(
-			this.filePath,
-			new Uint8Array(await file.arrayBuffer())
-		)
+	async compileFile(file: File | VirtualFile) {
+		const [dependencies, compiled] =
+			await this.app.project.compilerService.compileFile(
+				this.filePath,
+				new Uint8Array(await file.arrayBuffer())
+			)
 
 		this.children.forEach((child) => child.dispose())
 		this.children = []
@@ -59,7 +58,7 @@ export class FileWatcher extends EventDispatcher<File> {
 		return new File([compiled], file.name)
 	}
 
-	protected async onFileChange(file: File) {
+	protected async onFileChange(file: File | VirtualFile) {
 		this.dispatch(await this.compileFile(file))
 	}
 	async getFile() {
@@ -90,7 +89,7 @@ export class ChildFileWatcher extends EventDispatcher<void> {
 		)
 	}
 
-	protected async onFileChange(data: File) {
+	protected async onFileChange(data: File | VirtualFile) {
 		this.dispatch()
 	}
 	dispose() {

--- a/src/components/FileSystem/Virtual/File.ts
+++ b/src/components/FileSystem/Virtual/File.ts
@@ -2,7 +2,8 @@ import { BaseStore } from './Stores/BaseStore'
 
 const textDecoder = new TextDecoder()
 
-export class VirtualFile implements File {
+export class VirtualFile {
+	public readonly isVirtual = true
 	public readonly type: string
 	public readonly lastModified: number
 	public readonly size: number
@@ -18,14 +19,8 @@ export class VirtualFile implements File {
 		this.lastModified = lastModified
 	}
 
-	static async for(baseStore: BaseStore, path: string): Promise<File> {
+	static async for(baseStore: BaseStore, path: string): Promise<VirtualFile> {
 		return new VirtualFile(baseStore, path, await baseStore.metadata(path))
-	}
-	get webkitRelativePath(): string {
-		throw new Error('Method not implemented')
-	}
-	slice(): Blob {
-		throw new Error('Method not implemented')
 	}
 
 	get name() {
@@ -57,8 +52,10 @@ export class VirtualFile implements File {
 		})
 	}
 
-	async toBlob() {
-		return new Blob([await this.arrayBuffer()], { type: this.type })
+	async toBlobFile() {
+		return new File([await this.arrayBuffer()], this.name, {
+			type: this.type,
+		})
 	}
 }
 
@@ -68,3 +65,11 @@ function typedArrayToBuffer(array: Uint8Array): ArrayBuffer {
 		array.byteLength + array.byteOffset
 	)
 }
+
+declare global {
+	interface File {
+		isVirtual: false
+	}
+}
+
+File.prototype.isVirtual = false

--- a/src/components/FileSystem/Virtual/Stores/BaseStore.ts
+++ b/src/components/FileSystem/Virtual/Stores/BaseStore.ts
@@ -1,3 +1,5 @@
+import { VirtualFile } from '../File'
+
 export const FsKindEnum = <const>{
 	Directory: 0,
 	File: 1,
@@ -57,7 +59,7 @@ export abstract class BaseStore<T = any> {
 	/**
 	 * Read file
 	 */
-	abstract readFile(path: string): Promise<File>
+	abstract readFile(path: string): Promise<File | VirtualFile>
 
 	/**
 	 * Return when a file was last modified and its size

--- a/src/components/FileSystem/Virtual/Stores/TauriFs.ts
+++ b/src/components/FileSystem/Virtual/Stores/TauriFs.ts
@@ -76,7 +76,7 @@ export class TauriFsStore extends BaseStore<ITauriFsSerializedData> {
 		await writeBinaryFile(await this.resolvePath(path), data)
 	}
 
-	async readFile(path: string): Promise<File> {
+	async readFile(path: string): Promise<File | VirtualFile> {
 		return await VirtualFile.for(this, path)
 	}
 

--- a/src/components/ImportFile/BasicFile.ts
+++ b/src/components/ImportFile/BasicFile.ts
@@ -74,7 +74,11 @@ export class BasicFileImporter extends FileImporter {
 	protected async onSave(fileHandle: AnyFileHandle) {
 		const app = await App.getApp()
 
-		const guessedFolder = await App.fileType.guessFolder(fileHandle)
+		// Convince TypeScript that fileHandle is a FileSystemFileHandle
+		// We do that because our VirtualFileHandle's getFile method always returns a File object that is sufficient for the guessFolder method
+		const guessedFolder = await App.fileType.guessFolder(
+			<FileSystemFileHandle>fileHandle
+		)
 
 		// Allow user to change file path that the file is saved to
 		const filePathWindow = new FilePathWindow({

--- a/src/components/PackIndexer/Worker/LightningCache/LightningCache.ts
+++ b/src/components/PackIndexer/Worker/LightningCache/LightningCache.ts
@@ -12,6 +12,7 @@ import {
 } from '/@/components/FileSystem/Types'
 import { TPackTypeId } from '/@/components/Data/PackType'
 import { getCacheScriptEnv } from './CacheEnv'
+import type { VirtualFile } from '/@/components/FileSystem/Virtual/File'
 
 const knownTextFiles = new Set([
 	'.js',
@@ -224,7 +225,7 @@ export class LightningCache {
 	async processText(
 		filePath: string,
 		fileType: string,
-		file: File,
+		file: File | VirtualFile,
 		isForeignFile?: boolean
 	) {
 		const instructions = await this.fileType.getLightningCache(filePath)
@@ -269,7 +270,7 @@ export class LightningCache {
 	async processJSON(
 		filePath: string,
 		fileType: string,
-		file: File,
+		file: File | VirtualFile,
 		fileContent?: string,
 		isForeignFile?: boolean
 	) {

--- a/src/components/Projects/CreateProject/Files/PackIcon.ts
+++ b/src/components/Projects/CreateProject/Files/PackIcon.ts
@@ -3,6 +3,7 @@ import { ICreateProjectOptions } from '/@/components/Projects/CreateProject/Crea
 import { TPackType } from '/@/components/Projects/CreateProject/Packs/Pack'
 import { CreateFile } from './CreateFile'
 import { App } from '/@/App'
+import { VirtualFile } from '/@/components/FileSystem/Virtual/File'
 
 export class CreatePackIcon extends CreateFile {
 	public readonly id = 'packIcon'
@@ -13,7 +14,7 @@ export class CreatePackIcon extends CreateFile {
 	}
 
 	async create(fs: FileSystem, createOptions: ICreateProjectOptions) {
-		let icon = createOptions.icon
+		let icon: File | VirtualFile | null = createOptions.icon
 		if (!icon) {
 			const app = await App.getApp()
 			await app.dataLoader.fired
@@ -22,6 +23,9 @@ export class CreatePackIcon extends CreateFile {
 			)
 		}
 
-		await fs.writeFile(`${this.packPath}/pack_icon.png`, icon)
+		await fs.writeFile(
+			`${this.packPath}/pack_icon.png`,
+			icon.isVirtual ? await icon.toBlobFile() : icon
+		)
 	}
 }

--- a/src/components/Projects/Project/FileChangeRegistry.ts
+++ b/src/components/Projects/Project/FileChangeRegistry.ts
@@ -1,6 +1,7 @@
+import { VirtualFile } from '../../FileSystem/Virtual/File'
 import { EventSystem } from '/@/components/Common/Event/EventSystem'
 
-export class FileChangeRegistry<T = File> extends EventSystem<T> {
+export class FileChangeRegistry<T = File | VirtualFile> extends EventSystem<T> {
 	constructor() {
 		super([], true)
 	}

--- a/src/components/TabSystem/FileTab.ts
+++ b/src/components/TabSystem/FileTab.ts
@@ -64,7 +64,11 @@ export abstract class FileTab extends Tab {
 			this.isForeignFile = true
 
 			let guessedFolder =
-				(await App.fileType.guessFolder(this.fileHandle)) ?? uuid()
+				// Convince TypeScript that this is a FileSystemFileHandle
+				// We can do this because the VirtualFileHandle is sufficient for the guessFolder function
+				(await App.fileType.guessFolder(
+					<FileSystemFileHandle>this.fileHandle
+				)) ?? uuid()
 			if (!guessedFolder.endsWith('/')) guessedFolder += '/'
 
 			this.path = `${guessedFolder}${uuid()}/${this.fileHandle.name}`

--- a/src/utils/file/moveHandle.ts
+++ b/src/utils/file/moveHandle.ts
@@ -68,7 +68,7 @@ export async function moveFileHandle(
 
 	// 3. Write file content to new file
 	const writable = await newHandle.createWritable()
-	await writable.write(file)
+	await writable.write(file.isVirtual ? await file.toBlobFile() : file)
 	await writable.close()
 	// 4. Delete old file
 	if (fromHandle) await fromHandle.removeEntry(moveHandle.name)

--- a/src/utils/file/renameHandle.ts
+++ b/src/utils/file/renameHandle.ts
@@ -71,7 +71,7 @@ async function renameFileHandle(
 
 	// 3. Write file content to new file
 	const writable = await newHandle.createWritable()
-	await writable.write(file)
+	await writable.write(file.isVirtual ? await file.toBlobFile() : file)
 	await writable.close()
 	// 4. Delete old file
 	await parentHandle.removeEntry(renameHandle.name)

--- a/src/utils/loadAsDataUrl.ts
+++ b/src/utils/loadAsDataUrl.ts
@@ -21,7 +21,7 @@ export async function loadAsDataURL(filePath: string, fileSystem?: FileSystem) {
 			})
 			reader.addEventListener('error', reject)
 			reader.readAsDataURL(
-				file instanceof VirtualFile ? await file.toBlob() : file
+				file instanceof VirtualFile ? await file.toBlobFile() : file
 			)
 		} catch {
 			reject(`File does not exist: "${filePath}"`)
@@ -42,7 +42,7 @@ export function loadHandleAsDataURL(fileHandle: AnyFileHandle) {
 			reader.addEventListener('error', reject)
 
 			reader.readAsDataURL(
-				file instanceof VirtualFile ? await file.toBlob() : file
+				file instanceof VirtualFile ? await file.toBlobFile() : file
 			)
 		} catch {
 			reject(`File does not exist: "${fileHandle.name}"`)


### PR DESCRIPTION
## Description
This should fix issues with our virtual file once and for all. The `VirtualFile` class no longer implements all methods from the File interface and therefore also doesn't pretend to be a real file anymore. Due to this change, TypeScript could catch all problematic areas, where we need to be careful passing a VirtualFile to a web API
