### PR TITLE
feat: better update flow

### DIFF
--- a/src/components/App/Tauri/TauriUpdater.ts
+++ b/src/components/App/Tauri/TauriUpdater.ts
@@ -48,7 +48,7 @@ checkUpdate()
 			})
 		}
 	})
-	.catch(async (err: any) => {
+	.catch((err: any) => {
 		console.error(`[TauriUpdater] ${err}`)
 
 		return null

--- a/src/components/App/Tauri/TauriUpdater.ts
+++ b/src/components/App/Tauri/TauriUpdater.ts
@@ -1,9 +1,12 @@
 import { createNotification } from '../../Notifications/create'
 import { checkUpdate, installUpdate } from '@tauri-apps/api/updater'
 import { relaunch } from '@tauri-apps/api/process'
+import { App } from '/@/App'
 
 checkUpdate()
-	.then((update) => {
+	.then(async (update) => {
+		const app = await App.getApp()
+
 		if (update.shouldUpdate) {
 			const notification = createNotification({
 				icon: 'mdi-update',
@@ -13,15 +16,40 @@ checkUpdate()
 				onClick: async () => {
 					// Dispose the notification
 					notification.dispose()
+
+					// Task to indicate background progress
+					const task = app.taskManager.create({
+						icon: 'mdi-update',
+						name: 'sidebar.notifications.installingUpdate.name',
+						description:
+							'sidebar.notifications.installingUpdate.description',
+
+						indeterminate: true,
+					})
+
 					// Install the update
 					await installUpdate()
-					// ...and finally relaunch the app
-					await relaunch()
+					// Dispose task
+					task.complete()
+
+					// Create a notification to indicate that the app needs to be restarted
+					createNotification({
+						icon: 'mdi-update',
+						color: 'primary',
+						message:
+							'sidebar.notifications.restartToApplyUpdate.message',
+						textColor: 'white',
+						onClick: async () => {
+							// ...and finally relaunch the app
+							await relaunch()
+						},
+					})
 				},
 			})
 		}
 	})
-	.catch((err: any) => {
+	.catch(async (err: any) => {
 		console.error(`[TauriUpdater] ${err}`)
+
 		return null
 	})

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -89,6 +89,7 @@
 					size="24"
 					width="2"
 					color="white"
+					:indeterminate="task.progress === undefined"
 					:value="task.progress"
 				/>
 			</SidebarButton>

--- a/src/components/TaskManager/Task.ts
+++ b/src/components/TaskManager/Task.ts
@@ -6,6 +6,7 @@ export interface ITaskDetails {
 	name: string
 	description: string
 	totalTaskSteps?: number
+	indeterminate?: boolean
 }
 
 export class Task {
@@ -51,6 +52,8 @@ export class Task {
 		return this.taskDetails.icon
 	}
 	get progress() {
+		if (this.taskDetails.indeterminate) return undefined
+
 		return Math.round((this.currentStepCount / this.totalStepCount) * 100)
 	}
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -556,6 +556,13 @@
 			"updateAvailable": {
 				"message": "Update Available"
 			},
+			"installingUpdate": {
+				"name": "Installing Update",
+				"description": "bridge. is currently installing an update in the background."
+			},
+			"restartToApplyUpdate": {
+				"message": "Restart to Update"
+			},
 			"updateExtensions": "Update All Extensions"
 		}
 	},


### PR DESCRIPTION
## Description
This makes the following changes to our update flow on our native app:
- After the user clicks the "Update Available" notification, show a loading task to indicate that work is going on in the background
- When the update is installed successfully, dispose the task and show a new notification to restart the app
