### PR TITLE
fix: mobile context menu

### DIFF
--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -14,7 +14,7 @@
 		min-width="200px"
 		max-width="500px"
 	>
-		<v-card color="menu">
+		<v-card :height="`${18 + actionHeight}px`" color="menu">
 			<v-card-title v-if="contextMenu.card.title">
 				{{ contextMenu.card.title }}
 			</v-card-title>
@@ -72,6 +72,11 @@ export default {
 			if (!this.contextMenu || !this.contextMenu.actionManager.value)
 				return {}
 			return this.contextMenu.actionManager.value.state
+		},
+		actionHeight() {
+			return Object.values(this.actions)
+				.map((action) => (action.type === 'divider' ? 1 : 40))
+				.reduce((prev, curr) => prev + curr, 0)
 		},
 	},
 	watch: {

--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -14,7 +14,7 @@
 		min-width="200px"
 		max-width="500px"
 	>
-		<v-card :height="`${18 + actionHeight}px`" color="menu">
+		<v-card class="overflow-auto" color="menu">
 			<v-card-title v-if="contextMenu.card.title">
 				{{ contextMenu.card.title }}
 			</v-card-title>
@@ -22,7 +22,11 @@
 				{{ contextMenu.card.text }}
 			</v-card-text>
 			<v-divider v-if="contextMenu.card.text || contextMenu.card.title" />
-			<ContextMenuList @click="isVisible = false" :actions="actions" />
+			<ContextMenuList
+				:height="`${18 + actionHeight}px`"
+				@click="isVisible = false"
+				:actions="actions"
+			/>
 		</v-card>
 	</v-menu>
 </template>

--- a/src/components/ContextMenu/List.vue
+++ b/src/components/ContextMenu/List.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-list color="menu" dense>
+	<v-list :height="height" color="menu" dense>
 		<template v-for="(action, id) in renderActions">
 			<!-- Divider -->
 			<v-divider v-if="action.type === 'divider'" :key="id" />
@@ -122,6 +122,7 @@ import { pointerDevice } from '/@/utils/pointerDevice'
 const { t } = useTranslations()
 
 const props = defineProps({
+	height: String,
 	actions: {
 		type: Object,
 		required: true,


### PR DESCRIPTION
## Description
The context menu positioning doesn't take into account that categories expand on mobile. The easiest way to fix this is to add a fixed height to the context menu and to make it scrollable when expanding sections which is what this PR implements.

![Bildschirm­foto 2022-12-28 um 18 59 02](https://user-images.githubusercontent.com/33347616/209854681-ecb033d1-b5b2-49d3-b54b-24e307192dd3.png)

## Motivation
https://discord.com/channels/602097536404160523/602097536840237087/1057689226772217946
