### PR TITLE
feat: tree editor validation

### DIFF
--- a/src/components/Composables/useHighContrast.ts
+++ b/src/components/Composables/useHighContrast.ts
@@ -1,0 +1,10 @@
+import { computed } from 'vue'
+import { settingsState } from '../Windows/Settings/SettingsState'
+
+export function useHighContrast() {
+	return <const>{
+		highContrast: computed(
+			() => settingsState.appearance?.highContrast ?? false
+		),
+	}
+}

--- a/src/components/Editors/TreeEditor/History/DeleteEntry.ts
+++ b/src/components/Editors/TreeEditor/History/DeleteEntry.ts
@@ -25,6 +25,8 @@ export class UndoDeleteEntry extends HistoryEntry {
 			parent.children.splice(this.index, 0, this.tree)
 		else parent.children.splice(this.index, 0, [this.key, this.tree])
 
+		parent.requestValidation()
+
 		return new DeleteEntry(this.tree, this.index, this.key)
 	}
 }
@@ -50,6 +52,7 @@ export class DeleteEntry extends HistoryEntry {
 			)
 
 		parent.children.splice(this.index, 1)
+		parent.requestValidation()
 
 		return new UndoDeleteEntry(this.tree, this.index, this.key)
 	}

--- a/src/components/Editors/TreeEditor/History/DeleteEntry.ts
+++ b/src/components/Editors/TreeEditor/History/DeleteEntry.ts
@@ -25,8 +25,6 @@ export class UndoDeleteEntry extends HistoryEntry {
 			parent.children.splice(this.index, 0, this.tree)
 		else parent.children.splice(this.index, 0, [this.key, this.tree])
 
-		parent.requestValidation()
-
 		return new DeleteEntry(this.tree, this.index, this.key)
 	}
 }
@@ -52,7 +50,6 @@ export class DeleteEntry extends HistoryEntry {
 			)
 
 		parent.children.splice(this.index, 1)
-		parent.requestValidation()
 
 		return new UndoDeleteEntry(this.tree, this.index, this.key)
 	}

--- a/src/components/Editors/TreeEditor/History/MoveEntry.ts
+++ b/src/components/Editors/TreeEditor/History/MoveEntry.ts
@@ -33,7 +33,9 @@ export class MoveEntry extends HistoryEntry {
 		else
 			this.oldParent.children.splice(this.index, 0, [this.key, this.tree])
 
+		this.tree.getParent()?.requestValidation()
 		this.tree.setParent(this.oldParent)
+		this.oldParent.requestValidation()
 
 		return new MoveEntry(parent, this.tree, oldIndex, this.key)
 	}

--- a/src/components/Editors/TreeEditor/History/MoveEntry.ts
+++ b/src/components/Editors/TreeEditor/History/MoveEntry.ts
@@ -33,9 +33,7 @@ export class MoveEntry extends HistoryEntry {
 		else
 			this.oldParent.children.splice(this.index, 0, [this.key, this.tree])
 
-		this.tree.getParent()?.requestValidation()
 		this.tree.setParent(this.oldParent)
-		this.oldParent.requestValidation()
 
 		return new MoveEntry(parent, this.tree, oldIndex, this.key)
 	}

--- a/src/components/Editors/TreeEditor/History/ReplaceTree.ts
+++ b/src/components/Editors/TreeEditor/History/ReplaceTree.ts
@@ -9,7 +9,7 @@ export class ReplaceTreeEntry extends HistoryEntry {
 		protected newTree: Tree<unknown>
 	) {
 		super()
-		this.unselectTrees = [newTree]
+		this.unselectTrees = [newTree, oldTree]
 	}
 
 	undo() {

--- a/src/components/Editors/TreeEditor/InlineDiagnostic.vue
+++ b/src/components/Editors/TreeEditor/InlineDiagnostic.vue
@@ -1,7 +1,7 @@
 <template>
 	<span
 		v-if="diagnostic"
-		class="ml-4 d-inline-flex items-center font-thin text-xs opacity-50"
+		class="ml-4 d-inline-flex items-center font-thin text-xs opacity-50 cursor-default"
 		:class="{
 			'text-error': diagnostic.severity === 'error',
 			'text-warning': diagnostic.severity === 'warning',

--- a/src/components/Editors/TreeEditor/InlineDiagnostic.vue
+++ b/src/components/Editors/TreeEditor/InlineDiagnostic.vue
@@ -1,13 +1,16 @@
 <template>
 	<span
 		v-if="diagnostic"
-		class="font-thin text-xs opacity-50"
+		class="ml-4 d-inline-flex items-center font-thin text-xs opacity-50"
 		:class="{
 			'text-error': diagnostic.severity === 'error',
 			'text-warning': diagnostic.severity === 'warning',
 			'text-info': diagnostic.severity === 'info',
 		}"
 	>
+		<v-icon :color="diagnostic.severity" class="mr-1" small>
+			mdi-arrow-down
+		</v-icon>
 		{{ diagnostic.message }}
 	</span>
 </template>

--- a/src/components/Editors/TreeEditor/InlineDiagnostic.vue
+++ b/src/components/Editors/TreeEditor/InlineDiagnostic.vue
@@ -1,11 +1,12 @@
 <template>
 	<span
 		v-if="diagnostic"
-		class="ml-4 d-inline-flex items-center font-thin text-xs opacity-50 cursor-default"
+		class="ml-4 d-inline-flex items-center font-thin text-xs cursor-default"
 		:class="{
 			'text-error': diagnostic.severity === 'error',
 			'text-warning': diagnostic.severity === 'warning',
 			'text-info': diagnostic.severity === 'info',
+			'opacity-60': !highContrast,
 		}"
 	>
 		<v-icon :color="diagnostic.severity" class="mr-1" small>
@@ -16,10 +17,14 @@
 </template>
 
 <script setup lang="ts">
+import { useHighContrast } from '/@/components/Composables/useHighContrast'
+
 const props = defineProps<{
 	diagnostic: {
 		message: string
 		severity: 'error' | 'warning' | 'info'
 	}
 }>()
+
+const { highContrast } = useHighContrast()
 </script>

--- a/src/components/Editors/TreeEditor/InlineDiagnostic.vue
+++ b/src/components/Editors/TreeEditor/InlineDiagnostic.vue
@@ -1,0 +1,22 @@
+<template>
+	<span
+		v-if="diagnostic"
+		class="font-thin text-xs opacity-50"
+		:class="{
+			'text-error': diagnostic.severity === 'error',
+			'text-warning': diagnostic.severity === 'warning',
+			'text-info': diagnostic.severity === 'info',
+		}"
+	>
+		{{ diagnostic.message }}
+	</span>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+	diagnostic: {
+		message: string
+		severity: 'error' | 'warning' | 'info'
+	}
+}>()
+</script>

--- a/src/components/Editors/TreeEditor/Tab.ts
+++ b/src/components/Editors/TreeEditor/Tab.ts
@@ -10,6 +10,7 @@ import { InformationWindow } from '../../Windows/Common/Information/InformationW
 import { TreeValueSelection } from './TreeSelection'
 import { PrimitiveTree } from './Tree/PrimitiveTree'
 import { AnyFileHandle } from '../../FileSystem/Types'
+import { HistoryEntry } from './History/HistoryEntry'
 
 const throttledCacheUpdate = debounce<(tab: TreeTab) => Promise<void> | void>(
 	async (tab) => {
@@ -170,9 +171,14 @@ export class TreeTab extends FileTab {
 		if (this.isReadOnly) return
 
 		await this.copy()
-		this.treeEditor.forEachSelection((sel) =>
-			this.treeEditor.delete(sel.getTree())
-		)
+		const entries: HistoryEntry[] = []
+		this.treeEditor.forEachSelection((sel) => {
+			sel.dispose()
+			const entry = sel.delete()
+			if (entry) entries.push(entry)
+		})
+
+		this.treeEditor.pushAllHistoryEntries(entries)
 	}
 
 	async close() {

--- a/src/components/Editors/TreeEditor/Tab.vue
+++ b/src/components/Editors/TreeEditor/Tab.vue
@@ -33,7 +33,7 @@
 		<div
 			class="pr-4"
 			:style="`height: ${
-				height - !tab.isReadOnly * 194
+				height - !tab.isReadOnly * 230
 			}px; overflow: auto;`"
 			@blur="focusEditor"
 			@scroll="onScroll"
@@ -68,7 +68,7 @@
 				"
 				:item-value="(item) => item"
 				:menu-props="{
-					maxHeight: 124,
+					maxHeight: 120,
 					top: false,
 					contentClass: 'json-editor-suggestions-menu',
 					rounded: 'lg',
@@ -84,9 +84,15 @@
 				dense
 				hide-details
 				enterkeyhint="enter"
+				aria-autocomplete="false"
+				spellcheck="false"
+				auto-select-first
 			>
 				<template v-slot:item="{ item }">
-					<div style="width: 100%" @click="mayTrigger">
+					<div
+						style="width: 100%; white-space: nowrap"
+						@click="mayTrigger"
+					>
 						<v-icon class="mr-1" color="primary" small>
 							{{ getIcon(item) }}
 						</v-icon>
@@ -122,7 +128,7 @@
 				:items="valueSuggestions"
 				:item-value="(item) => item"
 				:menu-props="{
-					maxHeight: 124,
+					maxHeight: 120,
 					top: false,
 					contentClass: 'json-editor-suggestions-menu',
 					rounded: 'lg',
@@ -135,9 +141,15 @@
 				dense
 				hide-details
 				enterkeyhint="enter"
+				aria-autocomplete="false"
+				spellcheck="false"
+				auto-select-first
 			>
 				<template v-slot:item="{ item }">
-					<div style="width: 100%" @click="mayTrigger">
+					<div
+						style="width: 100%; white-space: nowrap"
+						@click="mayTrigger"
+					>
 						<v-icon class="mr-1" color="primary" small>
 							{{ getIcon(item) }}
 						</v-icon>
@@ -165,7 +177,7 @@
 				:items="editSuggestions"
 				:item-value="(item) => item"
 				:menu-props="{
-					maxHeight: 124,
+					maxHeight: 120,
 					top: false,
 					contentClass: 'json-editor-suggestions-menu',
 					rounded: 'lg',
@@ -177,9 +189,15 @@
 				dense
 				hide-details
 				enterkeyhint="enter"
+				aria-autocomplete="false"
+				spellcheck="false"
+				auto-select-first
 			>
 				<template v-slot:item="{ item }">
-					<div style="width: 100%" @click="mayTrigger">
+					<div
+						style="width: 100%; white-space: nowrap"
+						@click="mayTrigger"
+					>
 						<v-icon class="mr-1" color="primary" small>
 							{{ getIcon(item) }}
 						</v-icon>

--- a/src/components/Editors/TreeEditor/Tab.vue
+++ b/src/components/Editors/TreeEditor/Tab.vue
@@ -191,7 +191,6 @@
 				enterkeyhint="enter"
 				aria-autocomplete="false"
 				spellcheck="false"
-				auto-select-first
 			>
 				<template v-slot:item="{ item }">
 					<div

--- a/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
@@ -81,4 +81,25 @@ export class ArrayTree extends Tree<Array<unknown>> {
 			},
 		}
 	}
+
+	validate() {
+		this._cachedChildHasDiagnostics = null
+		this.children.forEach((child) => child.validate())
+
+		super.validate()
+	}
+
+	protected _cachedChildHasDiagnostics: boolean | null = null
+	get childHasDiagnostics() {
+		if (this._cachedChildHasDiagnostics !== null)
+			return this._cachedChildHasDiagnostics
+
+		this._cachedChildHasDiagnostics = this.children.some((child) => {
+			if (child.type === 'array' || child.type === 'object')
+				return (<ArrayTree | ObjectTree>child).childHasDiagnostics
+			return child.highestSeverityDiagnostic !== null
+		})
+
+		return this._cachedChildHasDiagnostics
+	}
 }

--- a/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
@@ -95,8 +95,11 @@ export class ArrayTree extends Tree<Array<unknown>> {
 
 		this._cachedChildHasDiagnostics = this.children.some((child) => {
 			if (child.type === 'array' || child.type === 'object')
-				return (<ArrayTree | ObjectTree>child).childHasDiagnostics
-			return child.highestSeverityDiagnostic !== null
+				return (
+					!!child.highestSeverityDiagnostic ||
+					(<ArrayTree | ObjectTree>child).childHasDiagnostics
+				)
+			return !!child.highestSeverityDiagnostic
 		})
 
 		return this._cachedChildHasDiagnostics

--- a/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
@@ -3,6 +3,7 @@ import { Tree, treeElementHeight } from './Tree'
 import ArrayTreeComponent from './CommonTree.vue'
 import type { ObjectTree } from './ObjectTree'
 import { markRaw } from 'vue'
+import { TreeEditor } from '../TreeEditor'
 
 export class ArrayTree extends Tree<Array<unknown>> {
 	public component = markRaw(ArrayTreeComponent)
@@ -11,7 +12,7 @@ export class ArrayTree extends Tree<Array<unknown>> {
 	protected _children: Tree<unknown>[]
 
 	constructor(
-		parent: ObjectTree | ArrayTree | null,
+		parent: ObjectTree | ArrayTree | TreeEditor | null,
 		protected _value: Array<unknown>
 	) {
 		super(parent)

--- a/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
@@ -56,6 +56,9 @@ export class ArrayTree extends Tree<Array<unknown>> {
 	}
 	addChild(child: Tree<unknown>) {
 		this._children.push(child)
+
+		// We need to update the parent because an if schema could potentially be affected
+		this.parent?.requestValidation()
 	}
 
 	setOpen(val: boolean, force = false) {
@@ -73,6 +76,9 @@ export class ArrayTree extends Tree<Array<unknown>> {
 		let newTree = this.children[newIndex]
 		this.children[newIndex] = oldTree
 		delete this.children[oldIndex]
+
+		// We need to update the parent because an if schema could potentially be affected
+		this.parent?.requestValidation()
 
 		return {
 			undo: () => {

--- a/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
@@ -56,9 +56,6 @@ export class ArrayTree extends Tree<Array<unknown>> {
 	}
 	addChild(child: Tree<unknown>) {
 		this._children.push(child)
-
-		// We need to update the parent because an if schema could potentially be affected
-		this.parent?.requestValidation()
 	}
 
 	setOpen(val: boolean, force = false) {
@@ -76,9 +73,6 @@ export class ArrayTree extends Tree<Array<unknown>> {
 		let newTree = this.children[newIndex]
 		this.children[newIndex] = oldTree
 		delete this.children[oldIndex]
-
-		// We need to update the parent because an if schema could potentially be affected
-		this.parent?.requestValidation()
 
 		return {
 			undo: () => {

--- a/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ArrayTree.ts
@@ -83,10 +83,9 @@ export class ArrayTree extends Tree<Array<unknown>> {
 	}
 
 	validate() {
-		this._cachedChildHasDiagnostics = null
-		this.children.forEach((child) => child.validate())
-
 		super.validate()
+
+		this.children.forEach((child) => child.requestValidation())
 	}
 
 	protected _cachedChildHasDiagnostics: boolean | null = null
@@ -101,5 +100,10 @@ export class ArrayTree extends Tree<Array<unknown>> {
 		})
 
 		return this._cachedChildHasDiagnostics
+	}
+
+	clearDiagnosticsCache() {
+		super.clearDiagnosticsCache()
+		this._cachedChildHasDiagnostics = null
 	}
 }

--- a/src/components/Editors/TreeEditor/Tree/CommonTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/CommonTree.vue
@@ -27,6 +27,16 @@
 			>
 				mdi-chevron-right
 			</v-icon>
+
+			<v-icon
+				v-if="!tree.isOpen && tree.childHasDiagnostics"
+				small
+				color="warning"
+				class="mr-1"
+			>
+				mdi-alert-circle-outline
+			</v-icon>
+
 			<span v-if="showArrayIndices || tree.parent.type === 'object'">
 				<!-- Debugging helper -->
 				<span v-if="isDevMode">

--- a/src/components/Editors/TreeEditor/Tree/CommonTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/CommonTree.vue
@@ -71,8 +71,6 @@
 			>
 				mdi-alert-circle-outline
 			</v-icon>
-
-			<InlineDiagnostic v-if="diagnostic" :diagnostic="diagnostic" />
 		</summary>
 
 		<TreeChildren
@@ -93,7 +91,6 @@
 
 <script>
 import TreeChildren from './TreeChildren.vue'
-import InlineDiagnostic from '../InlineDiagnostic.vue'
 import { useLongPress } from '/@/components/Composables/LongPress'
 import { DevModeMixin } from '/@/components/Mixins/DevMode'
 import { settingsState } from '/@/components/Windows/Settings/SettingsState'
@@ -108,7 +105,6 @@ export default {
 	name: 'ObjectTree',
 	components: {
 		TreeChildren,
-		InlineDiagnostic,
 	},
 	mixins: [DevModeMixin],
 	props: {

--- a/src/components/Editors/TreeEditor/Tree/CommonTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/CommonTree.vue
@@ -72,6 +72,7 @@
 						v-on="on"
 						small
 						color="warning"
+						@click.stop
 					>
 						mdi-alert-circle-outline
 					</v-icon>

--- a/src/components/Editors/TreeEditor/Tree/CommonTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/CommonTree.vue
@@ -33,7 +33,21 @@
 					s: {{ tree.type }} p: {{ tree.parent.type }}
 				</span>
 
-				<span @dblclick="tree.toggleOpen()"> <slot /> </span
+				<span
+					class="decoration-wavy"
+					:class="{
+						underline: diagnostic,
+						'decoration-error':
+							diagnostic && diagnostic.severity === 'error',
+						'decoration-warning':
+							diagnostic && diagnostic.severity === 'warning',
+						'decoration-info':
+							diagnostic && diagnostic.severity === 'info',
+					}"
+					:title="diagnostic?.message"
+					@dblclick="tree.toggleOpen()"
+				>
+					<slot /> </span
 				>{{ hideBracketsWithinTreeEditor ? undefined : ':' }}</span
 			>
 			<!-- Spacer to make array objects easier to select -->
@@ -137,6 +151,9 @@ export default {
 
 			return this.tree.isOpen ? brackets[this.tree.type][1] : undefined
 		},
+		diagnostic() {
+			return this.tree.highestSeverityDiagnostic
+		},
 	},
 	methods: {
 		onClickKey(event) {
@@ -157,6 +174,7 @@ export default {
 
 <style scoped>
 .common-tree-key {
+	cursor: pointer;
 	list-style-type: none;
 	display: inline-block;
 	outline: none;

--- a/src/components/Editors/TreeEditor/Tree/CommonTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/CommonTree.vue
@@ -65,15 +65,13 @@
 			</span>
 
 			<!-- Error icon + tooltip -->
-			<v-tooltip color="warning" right>
+			<v-tooltip
+				v-if="!tree.isOpen && tree.childHasDiagnostics"
+				color="warning"
+				right
+			>
 				<template v-slot:activator="{ on }">
-					<v-icon
-						v-if="!tree.isOpen && tree.childHasDiagnostics"
-						v-on="on"
-						small
-						color="warning"
-						@click.stop
-					>
+					<v-icon v-on="on" small color="warning" @click.stop>
 						mdi-alert-circle-outline
 					</v-icon>
 				</template>

--- a/src/components/Editors/TreeEditor/Tree/CommonTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/CommonTree.vue
@@ -28,15 +28,6 @@
 				mdi-chevron-right
 			</v-icon>
 
-			<v-icon
-				v-if="!tree.isOpen && tree.childHasDiagnostics"
-				small
-				color="warning"
-				class="mr-1"
-			>
-				mdi-alert-circle-outline
-			</v-icon>
-
 			<span v-if="showArrayIndices || tree.parent.type === 'object'">
 				<!-- Debugging helper -->
 				<span v-if="isDevMode">
@@ -64,14 +55,22 @@
 			<span
 				v-else-if="!showArrayIndices"
 				:class="{
-					'mx-2': pointerDevice !== 'touch',
+					'mx-1': pointerDevice !== 'touch',
 					'mx-6': pointerDevice === 'touch',
 				}"
 			/>
 
-			<span class="px-1" @click.stop.prevent="tree.toggleOpen()">
+			<span class="pl-1" @click.stop.prevent="tree.toggleOpen()">
 				{{ openingBracket }}
 			</span>
+
+			<v-icon
+				v-if="!tree.isOpen && tree.childHasDiagnostics"
+				small
+				color="warning"
+			>
+				mdi-alert-circle-outline
+			</v-icon>
 		</summary>
 
 		<TreeChildren

--- a/src/components/Editors/TreeEditor/Tree/CommonTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/CommonTree.vue
@@ -71,6 +71,8 @@
 			>
 				mdi-alert-circle-outline
 			</v-icon>
+
+			<InlineDiagnostic v-if="diagnostic" :diagnostic="diagnostic" />
 		</summary>
 
 		<TreeChildren
@@ -91,6 +93,7 @@
 
 <script>
 import TreeChildren from './TreeChildren.vue'
+import InlineDiagnostic from '../InlineDiagnostic.vue'
 import { useLongPress } from '/@/components/Composables/LongPress'
 import { DevModeMixin } from '/@/components/Mixins/DevMode'
 import { settingsState } from '/@/components/Windows/Settings/SettingsState'
@@ -105,6 +108,7 @@ export default {
 	name: 'ObjectTree',
 	components: {
 		TreeChildren,
+		InlineDiagnostic,
 	},
 	mixins: [DevModeMixin],
 	props: {

--- a/src/components/Editors/TreeEditor/Tree/CommonTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/CommonTree.vue
@@ -64,13 +64,20 @@
 				{{ openingBracket }}
 			</span>
 
-			<v-icon
-				v-if="!tree.isOpen && tree.childHasDiagnostics"
-				small
-				color="warning"
-			>
-				mdi-alert-circle-outline
-			</v-icon>
+			<!-- Error icon + tooltip -->
+			<v-tooltip color="warning" right>
+				<template v-slot:activator="{ on }">
+					<v-icon
+						v-if="!tree.isOpen && tree.childHasDiagnostics"
+						v-on="on"
+						small
+						color="warning"
+					>
+						mdi-alert-circle-outline
+					</v-icon>
+				</template>
+				<span>{{ t('editors.treeEditor.childHasError') }}</span>
+			</v-tooltip>
 		</summary>
 
 		<TreeChildren
@@ -93,6 +100,7 @@
 import TreeChildren from './TreeChildren.vue'
 import { useLongPress } from '/@/components/Composables/LongPress'
 import { DevModeMixin } from '/@/components/Mixins/DevMode'
+import { TranslationMixin } from '/@/components/Mixins/TranslationMixin'
 import { settingsState } from '/@/components/Windows/Settings/SettingsState'
 import { pointerDevice } from '/@/utils/pointerDevice'
 
@@ -106,7 +114,7 @@ export default {
 	components: {
 		TreeChildren,
 	},
-	mixins: [DevModeMixin],
+	mixins: [DevModeMixin, TranslationMixin],
 	props: {
 		tree: Object,
 		treeKey: String,

--- a/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
@@ -59,6 +59,9 @@ export class ObjectTree extends Tree<object> {
 	}
 	addChild(key: string, child: Tree<unknown>) {
 		this._children.push([key, child])
+
+		// We need to update the parent because an if schema could potentially be affected
+		this.parent?.requestValidation()
 	}
 
 	setOpen(val: boolean, force = false) {

--- a/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
@@ -3,6 +3,7 @@ import { Tree, treeElementHeight } from './Tree'
 import ObjecTreeComponent from './CommonTree.vue'
 import type { ArrayTree } from './ArrayTree'
 import { set, del, markRaw } from 'vue'
+import { TreeEditor } from '../TreeEditor'
 
 export class ObjectTree extends Tree<object> {
 	public component = markRaw(ObjecTreeComponent)
@@ -11,7 +12,7 @@ export class ObjectTree extends Tree<object> {
 	protected _children: [string, Tree<unknown>][]
 
 	constructor(
-		parent: ObjectTree | ArrayTree | null,
+		parent: ObjectTree | ArrayTree | TreeEditor | null,
 		protected _value: object
 	) {
 		super(parent)
@@ -19,6 +20,8 @@ export class ObjectTree extends Tree<object> {
 			key,
 			createTree(this, val),
 		])
+
+		this.requestValidation()
 	}
 
 	get height() {
@@ -91,5 +94,12 @@ export class ObjectTree extends Tree<object> {
 		}
 
 		set(this.children, oldIndex, [newName, oldTree])
+		this.requestValidation()
+	}
+
+	validate() {
+		this.children.forEach(([, child]) => child.validate())
+
+		super.validate()
 	}
 }

--- a/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
@@ -109,8 +109,11 @@ export class ObjectTree extends Tree<object> {
 
 		this._cachedChildHasDiagnostics = this.children.some(([, child]) => {
 			if (child.type === 'array' || child.type === 'object')
-				return (<ArrayTree | ObjectTree>child).childHasDiagnostics
-			return child.highestSeverityDiagnostic !== null
+				return (
+					!!child.highestSeverityDiagnostic ||
+					(<ArrayTree | ObjectTree>child).childHasDiagnostics
+				)
+			return !!child.highestSeverityDiagnostic
 		})
 
 		return this._cachedChildHasDiagnostics

--- a/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
@@ -97,10 +97,9 @@ export class ObjectTree extends Tree<object> {
 	}
 
 	validate() {
-		this._cachedChildHasDiagnostics = null
-		this.children.forEach(([, child]) => child.validate())
-
 		super.validate()
+
+		this.children.forEach(([, child]) => child.requestValidation())
 	}
 
 	protected _cachedChildHasDiagnostics: boolean | null = null
@@ -115,5 +114,9 @@ export class ObjectTree extends Tree<object> {
 		})
 
 		return this._cachedChildHasDiagnostics
+	}
+	clearDiagnosticsCache() {
+		super.clearDiagnosticsCache()
+		this._cachedChildHasDiagnostics = null
 	}
 }

--- a/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/ObjectTree.ts
@@ -59,9 +59,6 @@ export class ObjectTree extends Tree<object> {
 	}
 	addChild(key: string, child: Tree<unknown>) {
 		this._children.push([key, child])
-
-		// We need to update the parent because an if schema could potentially be affected
-		this.parent?.requestValidation()
 	}
 
 	setOpen(val: boolean, force = false) {
@@ -95,8 +92,6 @@ export class ObjectTree extends Tree<object> {
 		}
 
 		set(this.children, oldIndex, [newName, oldTree])
-		// We need to update the parent because an if schema could potentially be affected
-		this.parent?.requestValidation()
 	}
 
 	validate() {

--- a/src/components/Editors/TreeEditor/Tree/PrimitiveTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/PrimitiveTree.ts
@@ -43,9 +43,6 @@ export class PrimitiveTree extends Tree<TPrimitiveTree> {
 		else if (!Number.isNaN(Number(value))) this.setValue(Number(value))
 		else if (value === 'null') this.setValue(null)
 		else this.setValue(value)
-
-		// We need to update the parent because an if schema could potentially be affected
-		this.parent?.requestValidation()
 	}
 
 	isEmpty() {

--- a/src/components/Editors/TreeEditor/Tree/PrimitiveTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/PrimitiveTree.ts
@@ -44,8 +44,8 @@ export class PrimitiveTree extends Tree<TPrimitiveTree> {
 		else if (value === 'null') this.setValue(null)
 		else this.setValue(value)
 
-		this.requestValidation()
-		console.log(this)
+		// We need to update the parent because an if schema could potentially be affected
+		this.parent?.requestValidation()
 	}
 
 	isEmpty() {

--- a/src/components/Editors/TreeEditor/Tree/PrimitiveTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/PrimitiveTree.ts
@@ -3,13 +3,14 @@ import PrimitiveTreeComponent from './PrimitiveTree.vue'
 import type { ArrayTree } from './ArrayTree'
 import type { ObjectTree } from './ObjectTree'
 import { markRaw } from 'vue'
+import { TreeEditor } from '../TreeEditor'
 
 export class PrimitiveTree extends Tree<TPrimitiveTree> {
 	public component = markRaw(PrimitiveTreeComponent)
 	public isValueSelected = false
 
 	constructor(
-		parent: ObjectTree | ArrayTree | null,
+		parent: ObjectTree | ArrayTree | TreeEditor | null,
 		protected _value: TPrimitiveTree
 	) {
 		super(parent)
@@ -42,6 +43,9 @@ export class PrimitiveTree extends Tree<TPrimitiveTree> {
 		else if (!Number.isNaN(Number(value))) this.setValue(Number(value))
 		else if (value === 'null') this.setValue(null)
 		else this.setValue(value)
+
+		this.requestValidation()
+		console.log(this)
 	}
 
 	isEmpty() {

--- a/src/components/Editors/TreeEditor/Tree/PrimitiveTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/PrimitiveTree.vue
@@ -10,6 +10,7 @@
 		<div
 			style="display: inline-block"
 			:class="{
+				'cursor-pointer': true,
 				'tree-editor-selection':
 					tree.type !== 'object' &&
 					tree.type !== 'array' &&
@@ -27,7 +28,21 @@
 				mdi-chevron-right
 			</v-icon>
 			<span v-if="tree.parent.type === 'object'">
-				<span @click.stop.prevent="onClickKey"><slot /></span>:</span
+				<span
+					class="decoration-wavy"
+					:class="{
+						underline: diagnostic,
+						'decoration-error':
+							diagnostic && diagnostic.severity === 'error',
+						'decoration-warning':
+							diagnostic && diagnostic.severity === 'warning',
+						'decoration-info':
+							diagnostic && diagnostic.severity === 'info',
+					}"
+					:title="diagnostic?.message"
+					@click.stop.prevent="onClickKey"
+					><slot /></span
+				>:</span
 			>
 		</div>
 
@@ -46,6 +61,7 @@
 			:class="{
 				'tree-editor-selection': tree.isValueSelected,
 				'px-1': true,
+				'cursor-pointer': true,
 			}"
 			@click.stop.prevent.native="onClickKey($event, true)"
 			@contextmenu.prevent.native="
@@ -144,6 +160,9 @@ export default {
 			if (this.highlighterInfo.isItalic)
 				this.highlighterInfo.textDecoration += ' italic'
 			return this.highlighterInfo.textDecoration
+		},
+		diagnostic() {
+			return this.tree.highestSeverityDiagnostic
 		},
 	},
 	methods: {

--- a/src/components/Editors/TreeEditor/Tree/PrimitiveTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/PrimitiveTree.vue
@@ -74,13 +74,10 @@
 		>
 			{{ treeValue }}
 		</Highlight>
-
-		<InlineDiagnostic v-if="diagnostic" :diagnostic="diagnostic" />
 	</div>
 </template>
 
 <script>
-import InlineDiagnostic from '../InlineDiagnostic.vue'
 import Highlight from '../Highlight.vue'
 import { DevModeMixin } from '/@/components/Mixins/DevMode'
 import { HighlighterMixin } from '/@/components/Mixins/Highlighter'
@@ -88,7 +85,7 @@ import { useLongPress } from '/@/components/Composables/LongPress'
 import { pointerDevice } from '/@/utils/pointerDevice'
 
 export default {
-	components: { Highlight, InlineDiagnostic },
+	components: { Highlight },
 	name: 'PrimitiveTree',
 	mixins: [HighlighterMixin(['atom', 'string', 'number']), DevModeMixin],
 	props: {

--- a/src/components/Editors/TreeEditor/Tree/PrimitiveTree.vue
+++ b/src/components/Editors/TreeEditor/Tree/PrimitiveTree.vue
@@ -74,10 +74,13 @@
 		>
 			{{ treeValue }}
 		</Highlight>
+
+		<InlineDiagnostic v-if="diagnostic" :diagnostic="diagnostic" />
 	</div>
 </template>
 
 <script>
+import InlineDiagnostic from '../InlineDiagnostic.vue'
 import Highlight from '../Highlight.vue'
 import { DevModeMixin } from '/@/components/Mixins/DevMode'
 import { HighlighterMixin } from '/@/components/Mixins/Highlighter'
@@ -85,7 +88,7 @@ import { useLongPress } from '/@/components/Composables/LongPress'
 import { pointerDevice } from '/@/utils/pointerDevice'
 
 export default {
-	components: { Highlight },
+	components: { Highlight, InlineDiagnostic },
 	name: 'PrimitiveTree',
 	mixins: [HighlighterMixin(['atom', 'string', 'number']), DevModeMixin],
 	props: {

--- a/src/components/Editors/TreeEditor/Tree/Tree.ts
+++ b/src/components/Editors/TreeEditor/Tree/Tree.ts
@@ -3,6 +3,9 @@ import { v4 as uuid } from 'uuid'
 import type { ArrayTree } from './ArrayTree'
 import type { ObjectTree } from './ObjectTree'
 import { pointerDevice } from '/@/utils/pointerDevice'
+import type { TreeEditor } from '../TreeEditor'
+import { IDiagnostic } from '/@/components/JSONSchema/Schema/Schema'
+import { whenIdle } from '/@/utils/whenIdle'
 export type TPrimitiveTree = string | number | boolean | null
 export type TTree = TPrimitiveTree | Object | Array<unknown>
 
@@ -16,8 +19,18 @@ export abstract class Tree<T> {
 	public abstract height: number
 	protected abstract _value: T
 	abstract toJSON(): T
+	protected parent: ObjectTree | ArrayTree | null = null
+	protected _treeEditor: TreeEditor | null = null
+	protected diagnostics: IDiagnostic[] = []
 
-	constructor(protected parent: ObjectTree | ArrayTree | null) {}
+	constructor(parent: ObjectTree | ArrayTree | TreeEditor | null) {
+		if (parent?.type === 'treeEditor') {
+			this.parent = null
+			this._treeEditor = parent
+		} else {
+			this.parent = <ObjectTree | ArrayTree | null>parent
+		}
+	}
 
 	get value() {
 		return this._value
@@ -27,6 +40,11 @@ export abstract class Tree<T> {
 	}
 	setParent(parent: ObjectTree | ArrayTree | null) {
 		this.parent = parent
+	}
+	get treeEditor(): TreeEditor {
+		if (this._treeEditor) return this._treeEditor
+		if (!this.parent) throw new Error(`Tree has no parent or treeEditor`)
+		return this.parent.treeEditor
 	}
 	get path(): (string | number)[] {
 		if (!this.parent) return []
@@ -115,5 +133,31 @@ export abstract class Tree<T> {
 		const [deleted] = this.parent.children.splice(index, 1)
 
 		return <const>[index, Array.isArray(deleted) ? deleted[0] : '']
+	}
+
+	validate() {
+		this.diagnostics = this.treeEditor
+			.getSchemas(this)
+			.map((schema) => schema.validate(this.toJSON()))
+			.flat()
+	}
+	requestValidation() {
+		whenIdle(() => this.validate())
+	}
+
+	get highestSeverityDiagnostic() {
+		let highestSeverity: IDiagnostic | null = null
+
+		for (const diagnostic of this.diagnostics) {
+			if (diagnostic.severity === 'error') return diagnostic
+			else if (
+				diagnostic.severity === 'warning' &&
+				(!highestSeverity || highestSeverity.severity === 'info')
+			)
+				highestSeverity = diagnostic
+			else if (!highestSeverity) highestSeverity = diagnostic
+		}
+
+		return highestSeverity
 	}
 }

--- a/src/components/Editors/TreeEditor/Tree/Tree.ts
+++ b/src/components/Editors/TreeEditor/Tree/Tree.ts
@@ -142,14 +142,6 @@ export abstract class Tree<T> {
 	}
 
 	validate() {
-		if (this.value === 'bridge:test')
-			console.log(
-				this.treeEditor.getSchemas(this),
-				this.treeEditor
-					.getSchemas(this)
-					.map((schema) => schema.validate(this.toJSON()))
-			)
-
 		let hadDiagnostics = this.diagnostics.length > 0
 
 		this.diagnostics = this.treeEditor

--- a/src/components/Editors/TreeEditor/Tree/Tree.ts
+++ b/src/components/Editors/TreeEditor/Tree/Tree.ts
@@ -143,6 +143,13 @@ export abstract class Tree<T> {
 
 	validate() {
 		this._cachedHighestSeverityDiagnostic = null
+		if (this.value === 'bridge:test')
+			console.log(
+				this.treeEditor.getSchemas(this),
+				this.treeEditor
+					.getSchemas(this)
+					.map((schema) => schema.validate(this.toJSON()))
+			)
 
 		this.diagnostics = this.treeEditor
 			.getSchemas(this)

--- a/src/components/Editors/TreeEditor/Tree/Tree.ts
+++ b/src/components/Editors/TreeEditor/Tree/Tree.ts
@@ -148,6 +148,7 @@ export abstract class Tree<T> {
 			.getSchemas(this)
 			.map((schema) => schema.validate(this.toJSON()))
 			.flat()
+			.reverse()
 
 		// There are two cases in which we need to clear the parent's cache:
 		// 1. We had diagnostics and now we don't

--- a/src/components/Editors/TreeEditor/Tree/Tree.ts
+++ b/src/components/Editors/TreeEditor/Tree/Tree.ts
@@ -141,8 +141,10 @@ export abstract class Tree<T> {
 		return <const>[index, Array.isArray(deleted) ? deleted[0] : '']
 	}
 
-	validate() {
-		this._cachedHighestSeverityDiagnostic = null
+	validate(first = true) {
+		if (first) this.clearParentDiagnosticCache()
+		else this.clearDiagnosticsCache()
+
 		if (this.value === 'bridge:test')
 			console.log(
 				this.treeEditor.getSchemas(this),
@@ -181,5 +183,13 @@ export abstract class Tree<T> {
 
 		this._cachedHighestSeverityDiagnostic = highestSeverity
 		return highestSeverity
+	}
+
+	clearDiagnosticsCache() {
+		this._cachedHighestSeverityDiagnostic = null
+	}
+	clearParentDiagnosticCache() {
+		this.clearDiagnosticsCache()
+		this.parent?.clearParentDiagnosticCache()
 	}
 }

--- a/src/components/Editors/TreeEditor/Tree/Tree.ts
+++ b/src/components/Editors/TreeEditor/Tree/Tree.ts
@@ -40,8 +40,6 @@ export abstract class Tree<T> {
 	}
 	setParent(parent: ObjectTree | ArrayTree | null) {
 		this.parent = parent
-
-		this.parent?.requestValidation()
 	}
 	get treeEditor(): TreeEditor {
 		if (this._treeEditor) return this._treeEditor
@@ -106,8 +104,6 @@ export abstract class Tree<T> {
 			index,
 			this.parent.type === 'array' ? tree : [this.key, tree]
 		)
-
-		this.parent.requestValidation()
 	}
 
 	delete() {
@@ -136,8 +132,6 @@ export abstract class Tree<T> {
 
 		const [deleted] = this.parent.children.splice(index, 1)
 
-		this.parent.requestValidation()
-
 		return <const>[index, Array.isArray(deleted) ? deleted[0] : '']
 	}
 
@@ -148,7 +142,12 @@ export abstract class Tree<T> {
 			.getSchemas(this)
 			.map((schema) => schema.validate(this.toJSON()))
 			.flat()
-			.reverse()
+			// Sort by optional priority number
+			.sort((a, b) => {
+				if (a.priority === undefined) return 1
+				if (b.priority === undefined) return -1
+				return a.priority - b.priority
+			})
 
 		// There are two cases in which we need to clear the parent's cache:
 		// 1. We had diagnostics and now we don't

--- a/src/components/Editors/TreeEditor/Tree/TreeChildren.vue
+++ b/src/components/Editors/TreeEditor/Tree/TreeChildren.vue
@@ -10,7 +10,7 @@
 		>
 			<template v-for="[key, child] in children">
 				<InlineDiagnostic
-					v-if="child.highestSeverityDiagnostic"
+					v-if="showDiagnostics && child.highestSeverityDiagnostic"
 					:diagnostic="child.highestSeverityDiagnostic"
 					:key="`diagnostic.${child.uuid}`"
 				/>
@@ -80,6 +80,9 @@ export default {
 	computed: {
 		dragAndDropEnabled() {
 			return settingsState.editor?.dragAndDropTreeNodes ?? true
+		},
+		showDiagnostics() {
+			return settingsState.editor?.inlineTreeEditorDiagnostics ?? true
 		},
 		children: {
 			get() {

--- a/src/components/Editors/TreeEditor/Tree/TreeChildren.vue
+++ b/src/components/Editors/TreeEditor/Tree/TreeChildren.vue
@@ -8,19 +8,25 @@
 			:disabled="!dragAndDropEnabled || pointerDevice === 'touch'"
 			@change="onChange"
 		>
-			<component
-				v-for="[key, child] in children"
-				:key="child.uuid"
-				:is="child.component"
-				:tree="child"
-				:treeEditor="treeEditor"
-				@setActive="$emit('setActive')"
-			>
-				<span v-if="tree.type === 'array'" :style="numberDef">{{
-					key
-				}}</span>
-				<Highlight v-else :value="key" />
-			</component>
+			<template v-for="[key, child] in children">
+				<InlineDiagnostic
+					v-if="child.highestSeverityDiagnostic"
+					:diagnostic="child.highestSeverityDiagnostic"
+					:key="`diagnostic.${child.uuid}`"
+				/>
+				<component
+					:key="child.uuid"
+					:is="child.component"
+					:tree="child"
+					:treeEditor="treeEditor"
+					@setActive="$emit('setActive')"
+				>
+					<span v-if="tree.type === 'array'" :style="numberDef">{{
+						key
+					}}</span>
+					<Highlight v-else :value="key" />
+				</component>
+			</template>
 		</Draggable>
 	</div>
 </template>
@@ -33,6 +39,7 @@ import Draggable from 'vuedraggable'
 import { settingsState } from '/@/components/Windows/Settings/SettingsState.ts'
 import { MoveEntry } from '../History/MoveEntry.ts'
 import { HighlighterMixin } from '/@/components/Mixins/Highlighter'
+import InlineDiagnostic from '../InlineDiagnostic.vue'
 
 export default {
 	name: 'TreeChildren',
@@ -40,6 +47,7 @@ export default {
 	components: {
 		Highlight,
 		Draggable,
+		InlineDiagnostic,
 	},
 	props: {
 		tree: Object,

--- a/src/components/Editors/TreeEditor/Tree/TreeChildren.vue
+++ b/src/components/Editors/TreeEditor/Tree/TreeChildren.vue
@@ -66,6 +66,7 @@ export default {
 				)
 			} else if (event.added) {
 				event.added.element[1].parent = this.tree
+				this.tree.requestValidation()
 			}
 		},
 	},

--- a/src/components/Editors/TreeEditor/Tree/TreeChildren.vue
+++ b/src/components/Editors/TreeEditor/Tree/TreeChildren.vue
@@ -66,7 +66,6 @@ export default {
 				)
 			} else if (event.added) {
 				event.added.element[1].parent = this.tree
-				this.tree.requestValidation()
 			}
 		},
 	},

--- a/src/components/Editors/TreeEditor/Tree/createTree.ts
+++ b/src/components/Editors/TreeEditor/Tree/createTree.ts
@@ -2,9 +2,10 @@ import { ObjectTree } from './ObjectTree'
 import { Tree } from './Tree'
 import { ArrayTree } from './ArrayTree'
 import { PrimitiveTree } from './PrimitiveTree'
+import { TreeEditor } from '../TreeEditor'
 
 export function createTree(
-	parent: ObjectTree | ArrayTree | null,
+	parent: ObjectTree | ArrayTree | TreeEditor,
 	value: unknown
 ): Tree<unknown> {
 	if (value === null) return new PrimitiveTree(parent, null)

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -259,29 +259,10 @@ export class TreeEditor {
 				const entries: HistoryEntry[] = []
 
 				this.forEachSelection((sel) => {
-					const tree = sel.getTree()
-					if (!tree.getParent()) return // May not delete global tree
-
 					sel.dispose()
 
-					if (
-						sel instanceof TreeValueSelection &&
-						tree.getParent()!.type === 'object'
-					) {
-						// A delete action on a primitive value replaces the PrimitiveTree with an emtpy ObjectTree
-						const newTree = new ObjectTree(tree.getParent(), {})
-						this.setSelection(newTree)
-
-						tree.replace(newTree)
-
-						entries.push(new ReplaceTreeEntry(tree, newTree))
-					} else {
-						this.toggleSelection(tree.getParent()!)
-
-						const [index, key] = tree.delete()
-
-						entries.push(new UndoDeleteEntry(tree, index, key))
-					}
+					const entry = sel.delete()
+					if (entry) entries.push(entry)
 				})
 
 				this.history.pushAll(entries)
@@ -518,6 +499,13 @@ export class TreeEditor {
 				?.description ?? ''
 
 		return { title, text: description }
+	}
+
+	pushHistoryEntry(entry: HistoryEntry) {
+		this.history.push(entry)
+	}
+	pushAllHistoryEntries(entries: HistoryEntry[]) {
+		this.history.pushAll(entries)
 	}
 
 	onPasteMenu(event?: MouseEvent, tree = this.tree) {

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -78,14 +78,6 @@ export class TreeEditor {
 			this.parent.fileDidChange()
 		})
 
-		// Once schemas are loaded, validate files once
-		let didInitialValidation = false
-		const runInitialValidation = () => {
-			if (didInitialValidation) return
-			didInitialValidation = true
-			tree.requestValidation()
-		}
-
 		App.getApp().then(async (app) => {
 			await app.projectManager.projectReady.fired
 
@@ -93,14 +85,14 @@ export class TreeEditor {
 				if (!app.project.jsonDefaults.isReady) return
 
 				this.createSchemaRoot()
-				runInitialValidation()
+				if (this.parent.isSelected) tree.requestValidation()
 			})
 
 			app.project.jsonDefaults.on(() => {
 				if (!this.parent.hasFired) return
 
 				this.createSchemaRoot()
-				runInitialValidation()
+				if (this.parent.isSelected) tree.requestValidation()
 			})
 		})
 

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -187,7 +187,10 @@ export class TreeEditor {
 	}
 
 	getSchemas(tree: Tree<unknown> | undefined, next = false) {
-		if (this.selections.length === 0 || tree === this.tree) {
+		if (
+			(this.selections.length === 0 && tree === undefined) ||
+			tree === this.tree
+		) {
 			return this.schemaRoot ? [this.schemaRoot] : []
 		} else if (tree) {
 			let path = null
@@ -273,20 +276,6 @@ export class TreeEditor {
 			keyBinding: ['ESCAPE'],
 			onTrigger: () => {
 				this.setSelection(this.tree)
-			},
-		})
-
-		this.actions.create({
-			keyBinding: ['CTRL + Z'],
-			onTrigger: () => {
-				this.undo()
-			},
-		})
-
-		this.actions.create({
-			keyBinding: [platformRedoBinding],
-			onTrigger: () => {
-				this.redo()
 			},
 		})
 	}

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -63,8 +63,10 @@ export class TreeEditor {
 	}
 
 	constructor(protected parent: TreeTab, protected json: unknown) {
-		this.tree = createTree(this, json)
-		this.setSelection(this.tree)
+		const tree = createTree(this, json)
+		tree.validate()
+		this.setSelection(tree)
+		this.tree = tree
 
 		this.history.on((isUnsaved) => {
 			this.parent.setIsUnsaved(isUnsaved)

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -500,10 +500,9 @@ export class TreeEditor {
 
 		const title =
 			schemas.find((schema) => schema.title !== undefined)?.title ?? ''
-		const description = schemas
-			.filter((schema) => schema.description !== undefined)
-			.map((schema) => schema.description)
-			.join('\n')
+		const description =
+			schemas.filter((schema) => schema.description !== undefined)?.[0]
+				?.description ?? ''
 
 		return { title, text: description }
 	}

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -185,12 +185,14 @@ export class TreeEditor {
 		if (this.selections.length === 0 || tree === this.tree) {
 			return this.schemaRoot ? [this.schemaRoot] : []
 		} else if (tree) {
-			return (
-				this.schemaRoot?.getSchemasFor(
-					this.tree.toJSON(),
-					next ? [...tree.path, undefined] : tree.path
-				) ?? []
-			)
+			return [
+				...new Set(
+					this.schemaRoot?.getSchemasFor(
+						this.tree.toJSON(),
+						next ? [...tree.path, undefined] : tree.path
+					) ?? []
+				),
+			]
 		}
 
 		return []

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -30,6 +30,7 @@ import { filterDuplicates } from './CompletionItems/FilterDuplicates'
 import { inferType } from '/@/utils/inferType'
 
 export class TreeEditor {
+	public type = 'treeEditor'
 	public propertySuggestions: ICompletionItem[] = []
 	public valueSuggestions: ICompletionItem[] = []
 	public editSuggestions: ICompletionItem[] = []
@@ -62,7 +63,7 @@ export class TreeEditor {
 	}
 
 	constructor(protected parent: TreeTab, protected json: unknown) {
-		this.tree = createTree(null, json)
+		this.tree = createTree(this, json)
 		this.setSelection(this.tree)
 
 		this.history.on((isUnsaved) => {

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -198,12 +198,18 @@ export class TreeEditor {
 		if (this.selections.length === 0 || tree === this.tree) {
 			return this.schemaRoot ? [this.schemaRoot] : []
 		} else if (tree) {
+			let path = null
+			try {
+				path = next ? [...tree.path, undefined] : tree.path
+			} catch {
+				// An error may occur if the tree was deleted while a suggestion update was still scheduled
+				return []
+			}
+
 			return [
 				...new Set(
-					this.schemaRoot?.getSchemasFor(
-						this.tree.toJSON(),
-						next ? [...tree.path, undefined] : tree.path
-					) ?? []
+					this.schemaRoot?.getSchemasFor(this.tree.toJSON(), path) ??
+						[]
 				),
 			]
 		}

--- a/src/components/Editors/TreeEditor/TreeEditor.ts
+++ b/src/components/Editors/TreeEditor/TreeEditor.ts
@@ -181,10 +181,6 @@ export class TreeEditor {
 	}, 50)
 
 	createSchemaRoot() {
-		console.log(
-			this.parent.getPath(),
-			App.fileType.get(this.parent.getPath())
-		)
 		const schemaUri = App.fileType.get(this.parent.getPath())?.schema
 		if (schemaUri)
 			this.schemaRoot = SchemaManager.addRootSchema(

--- a/src/components/Editors/TreeEditor/TreeSelection.ts
+++ b/src/components/Editors/TreeEditor/TreeSelection.ts
@@ -1,5 +1,5 @@
 import { CollectedEntry } from './History/CollectedEntry'
-import { DeleteEntry } from './History/DeleteEntry'
+import { DeleteEntry, UndoDeleteEntry } from './History/DeleteEntry'
 import { EditPropertyEntry } from './History/EditPropertyEntry'
 import { EditValueEntry } from './History/EditValueEntry'
 import type { HistoryEntry } from './History/HistoryEntry'
@@ -120,6 +120,17 @@ export class TreeSelection {
 
 		return new CollectedEntry(historyEntries)
 	}
+
+	delete() {
+		const parent = this.tree.getParent()
+		if (!parent) return
+
+		this.parent.toggleSelection(parent)
+
+		const [index, key] = this.tree.delete()
+
+		return new UndoDeleteEntry(this.tree, index, key)
+	}
 }
 
 export class TreeValueSelection {
@@ -145,5 +156,26 @@ export class TreeValueSelection {
 		this.tree.edit(value)
 
 		return new EditValueEntry(this.tree, oldValue)
+	}
+
+	delete() {
+		const parent = this.tree.getParent()
+		if (!parent) return
+
+		if (parent.type === 'object') {
+			// A delete action on a primitive value replaces the PrimitiveTree with an emtpy ObjectTree
+			const newTree = new ObjectTree(parent, {})
+			this.parent.setSelection(newTree)
+
+			this.tree.replace(newTree)
+
+			return new ReplaceTreeEntry(this.tree, newTree)
+		} else {
+			this.parent.toggleSelection(parent)
+
+			const [index, key] = this.tree.delete()
+
+			return new UndoDeleteEntry(this.tree, index, key)
+		}
 	}
 }

--- a/src/components/Editors/TreeEditor/TreeSelection.ts
+++ b/src/components/Editors/TreeEditor/TreeSelection.ts
@@ -69,11 +69,11 @@ export class TreeSelection {
 			// Make sure to update parent reference before adding tree as child
 			newTree.setParent(addToTree)
 
-			this.tree.children.push(addToTree)
+			this.tree.addChild(addToTree)
 			addToTree.setOpen(true, true)
 		}
 
-		addToTree.children.push([key, newTree])
+		addToTree.addChild(key, newTree)
 		this.parent.setSelection(newTree)
 
 		this.tree.setOpen(true, true)

--- a/src/components/JSONSchema/Manager.ts
+++ b/src/components/JSONSchema/Manager.ts
@@ -39,6 +39,9 @@ export class SchemaManager {
 		}
 	}
 	static addRootSchema(location: string, rootSchema: RootSchema) {
+		// Do not cache dynamic schemas
+		if (location.includes('/dynamic/')) return
+
 		this.rootSchemas.set(location, rootSchema)
 		return rootSchema
 	}

--- a/src/components/JSONSchema/Registry.ts
+++ b/src/components/JSONSchema/Registry.ts
@@ -3,6 +3,7 @@ import { AllOfSchema } from './Schema/AllOf'
 import { AnyOfSchema } from './Schema/AnyOf'
 import { ConstSchema } from './Schema/Const'
 import { DefaultSchema } from './Schema/Default'
+import { DeprecationMessageSchema } from './Schema/DeprecationMessage'
 import { DoNotSuggestSchema } from './Schema/DoNotSuggest'
 import { ElseSchema } from './Schema/ElseSchema'
 import { EnumSchema } from './Schema/Enum'
@@ -41,6 +42,7 @@ export const schemaRegistry = new Map<string, ISchemaConstructor>([
 	['type', TypeSchema],
 	['default', DefaultSchema],
 	['else', ElseSchema],
+	['deprecationMessage', DeprecationMessageSchema],
 	['doNotSuggest', DoNotSuggestSchema],
 	['not', NotSchema],
 ])
@@ -58,7 +60,6 @@ export const ignoreFields = new Set<string>([
 	'max',
 	'maxItems',
 	'minItems',
-	'deprecationMessage',
 	'examples',
 	'minimum',
 	'maximum',

--- a/src/components/JSONSchema/Schema/AllOf.ts
+++ b/src/components/JSONSchema/Schema/AllOf.ts
@@ -26,4 +26,7 @@ export class AllOfSchema extends ParentSchema {
 		if (allDiagnostics.length === 0) return []
 		return allDiagnostics
 	}
+	isValid(obj: unknown) {
+		return this.children.every((child) => child.isValid(obj))
+	}
 }

--- a/src/components/JSONSchema/Schema/AllOf.ts
+++ b/src/components/JSONSchema/Schema/AllOf.ts
@@ -19,6 +19,11 @@ export class AllOfSchema extends ParentSchema {
 	}
 
 	validate(obj: unknown) {
-		return this.children.map((child) => child.validate(obj)).flat()
+		const allDiagnostics = this.children
+			.map((child) => child.validate(obj))
+			.flat()
+
+		if (allDiagnostics.length === 0) return []
+		return allDiagnostics
 	}
 }

--- a/src/components/JSONSchema/Schema/AnyOf.ts
+++ b/src/components/JSONSchema/Schema/AnyOf.ts
@@ -31,4 +31,7 @@ export class AnyOfSchema extends ParentSchema {
 
 		return allDiagnostics
 	}
+	isValid(obj: unknown) {
+		return this.children.some((child) => child.isValid(obj))
+	}
 }

--- a/src/components/JSONSchema/Schema/Const.ts
+++ b/src/components/JSONSchema/Schema/Const.ts
@@ -15,7 +15,8 @@ export class ConstSchema extends Schema {
 	validate(val: unknown) {
 		if (this.value !== val)
 			return [
-				{
+				<const>{
+					severity: 'error',
 					message: `Found ${val}; expected ${this.value}`,
 				},
 			]

--- a/src/components/JSONSchema/Schema/Const.ts
+++ b/src/components/JSONSchema/Schema/Const.ts
@@ -17,7 +17,7 @@ export class ConstSchema extends Schema {
 			return [
 				<const>{
 					severity: 'warning',
-					message: `Found ${val}; expected ${this.value}`,
+					message: `Found "${val}" here; expected "${this.value}"`,
 				},
 			]
 		return []

--- a/src/components/JSONSchema/Schema/Const.ts
+++ b/src/components/JSONSchema/Schema/Const.ts
@@ -16,7 +16,7 @@ export class ConstSchema extends Schema {
 		if (this.value !== val)
 			return [
 				<const>{
-					severity: 'error',
+					severity: 'warning',
 					message: `Found ${val}; expected ${this.value}`,
 				},
 			]

--- a/src/components/JSONSchema/Schema/DeprecationMessage.ts
+++ b/src/components/JSONSchema/Schema/DeprecationMessage.ts
@@ -1,0 +1,32 @@
+import { Schema } from './Schema'
+
+export class DeprecationMessageSchema extends Schema {
+	public readonly types = []
+
+	constructor(location: string, key: string, value: unknown) {
+		if (typeof value !== 'string') {
+			throw new Error(
+				`[${location}] Type of "deprecationMessage" must be string, found ${typeof value}`
+			)
+		}
+
+		super(location, key, value)
+	}
+
+	getSchemasFor() {
+		return []
+	}
+
+	getCompletionItems() {
+		return []
+	}
+
+	validate() {
+		return [
+			{
+				message: <string>this.value,
+				severity: <const>'warning',
+			},
+		]
+	}
+}

--- a/src/components/JSONSchema/Schema/ElseSchema.ts
+++ b/src/components/JSONSchema/Schema/ElseSchema.ts
@@ -35,7 +35,17 @@ export class ElseSchema extends Schema {
 	}
 
 	validate(obj: unknown) {
-		if (!this.ifSchema.isTrue(obj)) return this.rootSchema.validate(obj)
+		if (!this.ifSchema.isTrue(obj)) {
+			const diagnostics = this.rootSchema.validate(obj)
+
+			if (diagnostics.length > 0)
+				return [
+					<const>{
+						severity: 'warning',
+						message: `Invalid "else" schema`,
+					},
+				]
+		}
 		return []
 	}
 }

--- a/src/components/JSONSchema/Schema/ElseSchema.ts
+++ b/src/components/JSONSchema/Schema/ElseSchema.ts
@@ -38,13 +38,7 @@ export class ElseSchema extends Schema {
 		if (!this.ifSchema.isTrue(obj)) {
 			const diagnostics = this.rootSchema.validate(obj)
 
-			if (diagnostics.length > 0)
-				return [
-					<const>{
-						severity: 'warning',
-						message: `Invalid "else" schema`,
-					},
-				]
+			return diagnostics
 		}
 		return []
 	}

--- a/src/components/JSONSchema/Schema/Enum.ts
+++ b/src/components/JSONSchema/Schema/Enum.ts
@@ -21,14 +21,24 @@ export class EnumSchema extends Schema {
 	}
 
 	validate(val: unknown) {
-		if (!(<unknown[]>this.value).includes(val)) {
+		const values = <unknown[]>this.value
+		if (!values.includes(val)) {
+			if (values.length === 0) {
+				return [
+					<const>{
+						severity: 'warning',
+						message: `Found "${val}"; but no values are valid`,
+					},
+				]
+			}
+
 			// console.log(<unknown[]>this.value)
 			return [
 				<const>{
 					severity: 'warning',
-					message: `Found ${val}; expected one of ${(<unknown[]>(
-						this.value
-					)).join(', ')}`,
+					message: `Found "${val}"; expected one of ${values
+						.map((v) => `"${v}"`)
+						.join(', ')}`,
 				},
 			]
 		}

--- a/src/components/JSONSchema/Schema/Enum.ts
+++ b/src/components/JSONSchema/Schema/Enum.ts
@@ -21,15 +21,17 @@ export class EnumSchema extends Schema {
 	}
 
 	validate(val: unknown) {
-		if (!(<unknown[]>this.value).includes(val))
+		if (!(<unknown[]>this.value).includes(val)) {
+			// console.log(<unknown[]>this.value)
 			return [
 				<const>{
-					severity: 'error',
+					severity: 'warning',
 					message: `Found ${val}; expected one of ${(<unknown[]>(
 						this.value
 					)).join(', ')}`,
 				},
 			]
+		}
 		return []
 	}
 }

--- a/src/components/JSONSchema/Schema/Enum.ts
+++ b/src/components/JSONSchema/Schema/Enum.ts
@@ -23,7 +23,8 @@ export class EnumSchema extends Schema {
 	validate(val: unknown) {
 		if (!(<unknown[]>this.value).includes(val))
 			return [
-				{
+				<const>{
+					severity: 'error',
 					message: `Found ${val}; expected one of ${(<unknown[]>(
 						this.value
 					)).join(', ')}`,

--- a/src/components/JSONSchema/Schema/Enum.ts
+++ b/src/components/JSONSchema/Schema/Enum.ts
@@ -26,6 +26,7 @@ export class EnumSchema extends Schema {
 			if (values.length === 0) {
 				return [
 					<const>{
+						priority: 0,
 						severity: 'warning',
 						message: `Found "${val}"; but no values are valid`,
 					},
@@ -33,12 +34,15 @@ export class EnumSchema extends Schema {
 			}
 
 			// console.log(<unknown[]>this.value)
+			const exampleValues = values.slice(0, 3).map((v) => `"${v}"`)
+			if (values.length > 3) exampleValues.push('...')
 			return [
 				<const>{
+					priority: 1,
 					severity: 'warning',
-					message: `Found "${val}"; expected one of ${values
-						.map((v) => `"${v}"`)
-						.join(', ')}`,
+					message: `Found "${val}"; expected one of ${exampleValues.join(
+						', '
+					)}`,
 				},
 			]
 		}

--- a/src/components/JSONSchema/Schema/Enum.ts
+++ b/src/components/JSONSchema/Schema/Enum.ts
@@ -1,4 +1,5 @@
 import { Schema } from './Schema'
+import { closestMatch } from '/@/utils/string/closestMatch'
 
 export class EnumSchema extends Schema {
 	public readonly types = []
@@ -34,15 +35,18 @@ export class EnumSchema extends Schema {
 			}
 
 			// console.log(<unknown[]>this.value)
-			const exampleValues = values.slice(0, 3).map((v) => `"${v}"`)
-			if (values.length > 3) exampleValues.push('...')
+			const bestMatch = closestMatch(
+				`${val}`,
+				values.map((v) => `${v}`),
+				0.6
+			)
 			return [
 				<const>{
 					priority: 1,
 					severity: 'warning',
-					message: `Found "${val}"; expected one of ${exampleValues.join(
-						', '
-					)}`,
+					message: bestMatch
+						? `"${val}" not valid here. Did you mean "${bestMatch}"?`
+						: `"${val}" not valid here`,
 				},
 			]
 		}

--- a/src/components/JSONSchema/Schema/Not.ts
+++ b/src/components/JSONSchema/Schema/Not.ts
@@ -26,10 +26,19 @@ export class NotSchema extends Schema {
 	}
 
 	validate(obj: unknown) {
+		if (this.rootSchema.isValid(obj)) {
+			return [
+				<const>{
+					severity: 'warning',
+					message: 'Expected schema to be invalid',
+				},
+			]
+		}
+
 		return []
 	}
 
 	isValid(obj: unknown) {
-		return this.rootSchema.validate(obj).length > 0
+		return !this.rootSchema.isValid(obj)
 	}
 }

--- a/src/components/JSONSchema/Schema/OneOf.ts
+++ b/src/components/JSONSchema/Schema/OneOf.ts
@@ -42,6 +42,12 @@ export class OneOfSchema extends ParentSchema {
 				},
 			]
 		else if (matchedOne) return []
-		else return allDiagnostics
+		else
+			return [
+				<const>{
+					severity: 'warning',
+					message: `JSON did not match any schema, expected exactly one match`,
+				},
+			]
 	}
 }

--- a/src/components/JSONSchema/Schema/OneOf.ts
+++ b/src/components/JSONSchema/Schema/OneOf.ts
@@ -42,13 +42,7 @@ export class OneOfSchema extends ParentSchema {
 				},
 			]
 		else if (matchedOne) return []
-		else
-			return [
-				<const>{
-					severity: 'warning',
-					message: `JSON did not match any schema, expected exactly one match`,
-				},
-			]
+		else return allDiagnostics
 	}
 	isValid(obj: unknown) {
 		let matchedOne = false

--- a/src/components/JSONSchema/Schema/OneOf.ts
+++ b/src/components/JSONSchema/Schema/OneOf.ts
@@ -50,4 +50,15 @@ export class OneOfSchema extends ParentSchema {
 				},
 			]
 	}
+	isValid(obj: unknown) {
+		let matchedOne = false
+		for (const child of this.children) {
+			if (child.isValid(obj)) {
+				if (matchedOne) return false
+				matchedOne = true
+			}
+		}
+
+		return matchedOne
+	}
 }

--- a/src/components/JSONSchema/Schema/OneOf.ts
+++ b/src/components/JSONSchema/Schema/OneOf.ts
@@ -36,7 +36,8 @@ export class OneOfSchema extends ParentSchema {
 
 		if (hasTooManyMatches)
 			return [
-				{
+				<const>{
+					severity: 'warning',
 					message: `JSON matched more than one schema, expected exactly one match`,
 				},
 			]

--- a/src/components/JSONSchema/Schema/Parent.ts
+++ b/src/components/JSONSchema/Schema/Parent.ts
@@ -10,7 +10,8 @@ export abstract class ParentSchema extends Schema {
 
 	get hasDoNotSuggest() {
 		return this.children.some(
-			(child) => child instanceof DoNotSuggestSchema
+			(child) =>
+				child instanceof DoNotSuggestSchema || child.hasDoNotSuggest
 		)
 	}
 

--- a/src/components/JSONSchema/Schema/PatternProperties.ts
+++ b/src/components/JSONSchema/Schema/PatternProperties.ts
@@ -61,4 +61,22 @@ export class PatternPropertiesSchema extends Schema {
 
 		return []
 	}
+	isValid(obj: unknown) {
+		const isOwnValid = super.isValid(obj)
+		if (!isOwnValid) return false
+
+		for (const [pattern, child] of Object.entries(this.children)) {
+			const regExp = new RegExp(pattern)
+
+			for (const key in <any>obj) {
+				if (key.match(regExp) !== null) {
+					if (!child.isValid((<any>obj)[key])) return false
+				}
+			}
+
+			regExp.lastIndex = 0
+		}
+
+		return true
+	}
 }

--- a/src/components/JSONSchema/Schema/PatternProperties.ts
+++ b/src/components/JSONSchema/Schema/PatternProperties.ts
@@ -52,23 +52,13 @@ export class PatternPropertiesSchema extends Schema {
 		if (typeof obj !== 'object' || Array.isArray(obj))
 			return [
 				<const>{
-					severity: 'error',
+					severity: 'warning',
 					message: `Invalid type: Expected "object", received "${
 						Array.isArray(obj) ? 'array' : typeof obj
 					}"`,
 				},
 			]
 
-		const diagnostics: IDiagnostic[] = []
-
-		for (const key in obj) {
-			for (const [pattern, child] of Object.entries(this.children)) {
-				if (key.match(new RegExp(pattern)) === null) {
-					diagnostics.push(...child.validate((<any>obj)[key]))
-				}
-			}
-		}
-
-		return diagnostics
+		return []
 	}
 }

--- a/src/components/JSONSchema/Schema/PatternProperties.ts
+++ b/src/components/JSONSchema/Schema/PatternProperties.ts
@@ -53,9 +53,9 @@ export class PatternPropertiesSchema extends Schema {
 			return [
 				<const>{
 					severity: 'warning',
-					message: `This node is of type "${
+					message: `This node is of type ${
 						Array.isArray(obj) ? 'array' : typeof obj
-					}"; expected object`,
+					}; expected object`,
 				},
 			]
 

--- a/src/components/JSONSchema/Schema/PatternProperties.ts
+++ b/src/components/JSONSchema/Schema/PatternProperties.ts
@@ -51,7 +51,8 @@ export class PatternPropertiesSchema extends Schema {
 	validate(obj: unknown) {
 		if (typeof obj !== 'object' || Array.isArray(obj))
 			return [
-				{
+				<const>{
+					severity: 'error',
 					message: `Invalid type: Expected "object", received "${
 						Array.isArray(obj) ? 'array' : typeof obj
 					}"`,

--- a/src/components/JSONSchema/Schema/PatternProperties.ts
+++ b/src/components/JSONSchema/Schema/PatternProperties.ts
@@ -53,9 +53,9 @@ export class PatternPropertiesSchema extends Schema {
 			return [
 				<const>{
 					severity: 'warning',
-					message: `Invalid type: Expected "object", received "${
+					message: `This node is of type "${
 						Array.isArray(obj) ? 'array' : typeof obj
-					}"`,
+					}"; expected object`,
 				},
 			]
 

--- a/src/components/JSONSchema/Schema/Properties.ts
+++ b/src/components/JSONSchema/Schema/Properties.ts
@@ -83,22 +83,13 @@ export class PropertiesSchema extends Schema {
 		if (typeof obj !== 'object' || Array.isArray(obj))
 			return [
 				<const>{
-					severity: 'error',
+					severity: 'warning',
 					message: `Invalid type: Expected "object", received "${
 						Array.isArray(obj) ? 'array' : typeof obj
 					}"`,
 				},
 			]
 
-		const diagnostics: IDiagnostic[] = []
-
-		for (const key in obj) {
-			if (this.children[key])
-				diagnostics.push(
-					...this.children[key].validate((<any>obj)[key])
-				)
-		}
-
-		return diagnostics
+		return []
 	}
 }

--- a/src/components/JSONSchema/Schema/Properties.ts
+++ b/src/components/JSONSchema/Schema/Properties.ts
@@ -82,7 +82,8 @@ export class PropertiesSchema extends Schema {
 	validate(obj: unknown) {
 		if (typeof obj !== 'object' || Array.isArray(obj))
 			return [
-				{
+				<const>{
+					severity: 'error',
 					message: `Invalid type: Expected "object", received "${
 						Array.isArray(obj) ? 'array' : typeof obj
 					}"`,

--- a/src/components/JSONSchema/Schema/Properties.ts
+++ b/src/components/JSONSchema/Schema/Properties.ts
@@ -92,4 +92,20 @@ export class PropertiesSchema extends Schema {
 
 		return []
 	}
+	isValid(obj: unknown) {
+		console.log(
+			this.location,
+			obj,
+			super.isValid(obj) &&
+				Object.entries(this.children).every(([key, child]) =>
+					child.isValid((<any>obj)[key])
+				)
+		)
+		return (
+			super.isValid(obj) &&
+			Object.entries(this.children).every(([key, child]) =>
+				child.isValid((<any>obj)[key])
+			)
+		)
+	}
 }

--- a/src/components/JSONSchema/Schema/Properties.ts
+++ b/src/components/JSONSchema/Schema/Properties.ts
@@ -84,9 +84,9 @@ export class PropertiesSchema extends Schema {
 			return [
 				<const>{
 					severity: 'warning',
-					message: `Invalid type: Expected "object", received "${
+					message: `This node is of type "${
 						Array.isArray(obj) ? 'array' : typeof obj
-					}"`,
+					}"; expected object`,
 				},
 			]
 

--- a/src/components/JSONSchema/Schema/Properties.ts
+++ b/src/components/JSONSchema/Schema/Properties.ts
@@ -84,9 +84,9 @@ export class PropertiesSchema extends Schema {
 			return [
 				<const>{
 					severity: 'warning',
-					message: `This node is of type "${
+					message: `This node is of type ${
 						Array.isArray(obj) ? 'array' : typeof obj
-					}"; expected object`,
+					}; expected object`,
 				},
 			]
 

--- a/src/components/JSONSchema/Schema/Properties.ts
+++ b/src/components/JSONSchema/Schema/Properties.ts
@@ -93,14 +93,6 @@ export class PropertiesSchema extends Schema {
 		return []
 	}
 	isValid(obj: unknown) {
-		console.log(
-			this.location,
-			obj,
-			super.isValid(obj) &&
-				Object.entries(this.children).every(([key, child]) =>
-					child.isValid((<any>obj)[key])
-				)
-		)
 		return (
 			super.isValid(obj) &&
 			Object.entries(this.children).every(([key, child]) =>

--- a/src/components/JSONSchema/Schema/Ref.ts
+++ b/src/components/JSONSchema/Schema/Ref.ts
@@ -11,6 +11,10 @@ export class RefSchema extends Schema {
 		return this.rootSchema.types
 	}
 
+	get hasDoNotSuggest() {
+		return this.rootSchema.hasDoNotSuggest
+	}
+
 	constructor(location: string, key: string, value: unknown) {
 		super(location, key, value)
 

--- a/src/components/JSONSchema/Schema/Required.ts
+++ b/src/components/JSONSchema/Schema/Required.ts
@@ -16,7 +16,8 @@ export class RequiredSchema extends Schema {
 
 		if (typeof obj !== 'object' || Array.isArray(obj))
 			return [
-				{
+				<const>{
+					severity: 'error',
 					message: `Required properties missing: ${values.join(
 						', '
 					)}`,
@@ -25,7 +26,12 @@ export class RequiredSchema extends Schema {
 
 		for (const value of values) {
 			if ((<any>obj)[value] === undefined || (<any>obj)[value] === null)
-				return [{ message: `Missing required property: ${value}` }]
+				return [
+					<const>{
+						severity: 'error',
+						message: `Missing required property: ${value}`,
+					},
+				]
 		}
 		return []
 	}

--- a/src/components/JSONSchema/Schema/Required.ts
+++ b/src/components/JSONSchema/Schema/Required.ts
@@ -17,7 +17,7 @@ export class RequiredSchema extends Schema {
 		if (typeof obj !== 'object' || Array.isArray(obj))
 			return [
 				<const>{
-					severity: 'error',
+					severity: 'warning',
 					message: `Required properties missing: ${values.join(
 						', '
 					)}`,
@@ -28,7 +28,7 @@ export class RequiredSchema extends Schema {
 			if ((<any>obj)[value] === undefined || (<any>obj)[value] === null)
 				return [
 					<const>{
-						severity: 'error',
+						severity: 'warning',
 						message: `Missing required property: ${value}`,
 					},
 				]

--- a/src/components/JSONSchema/Schema/Required.ts
+++ b/src/components/JSONSchema/Schema/Required.ts
@@ -14,7 +14,7 @@ export class RequiredSchema extends Schema {
 	validate(obj: unknown) {
 		const values = Array.isArray(this.value) ? this.value : [this.value]
 
-		if (typeof obj !== 'object' || Array.isArray(obj))
+		if (Array.isArray(obj)) {
 			return [
 				<const>{
 					severity: 'warning',
@@ -23,6 +23,24 @@ export class RequiredSchema extends Schema {
 					)}`,
 				},
 			]
+		}
+
+		/**
+		 * @TODO - Support for passing down parent object so we can validate the parent object in the case described below.
+		 *
+		 * Case for key existence checks like this one:
+		 *
+		 * properties: {
+		 *   name: {
+		 *     required: ['name']
+		 *   }
+		 * }
+		 *
+		 * -> If typeof obj !== 'object, the validation should pass because we have no way to validate the parent object yet.
+		 */
+		if (typeof obj !== 'object') {
+			return []
+		}
 
 		for (const value of values) {
 			if ((<any>obj)[value] === undefined || (<any>obj)[value] === null)

--- a/src/components/JSONSchema/Schema/Root.ts
+++ b/src/components/JSONSchema/Schema/Root.ts
@@ -31,6 +31,9 @@ export class RootSchema extends ParentSchema {
 	validate(obj: unknown) {
 		return this.children.map((child) => child.validate(obj)).flat()
 	}
+	isValid(obj: unknown): boolean {
+		return this.children.every((child) => child.isValid(obj))
+	}
 
 	getFreeIfSchema(): IfSchema | undefined {
 		let isIfOccupied = false

--- a/src/components/JSONSchema/Schema/Schema.ts
+++ b/src/components/JSONSchema/Schema/Schema.ts
@@ -3,6 +3,7 @@ export interface ISchemaResult {
 }
 
 export interface IDiagnostic {
+	severity: 'error' | 'warning' | 'info'
 	message: string
 	// location: string
 }

--- a/src/components/JSONSchema/Schema/Schema.ts
+++ b/src/components/JSONSchema/Schema/Schema.ts
@@ -3,6 +3,7 @@ export interface ISchemaResult {
 }
 
 export interface IDiagnostic {
+	priority?: number
 	severity: 'error' | 'warning' | 'info'
 	message: string
 	// location: string

--- a/src/components/JSONSchema/Schema/Schema.ts
+++ b/src/components/JSONSchema/Schema/Schema.ts
@@ -28,6 +28,11 @@ export const pathWildCard = '-!<bridge:any-schema>!-'
 export abstract class Schema {
 	public readonly schemaType?: 'ifSchema' | 'refSchema'
 	public abstract readonly types: TSchemaType[]
+
+	public get hasDoNotSuggest() {
+		return false
+	}
+
 	constructor(
 		protected location: string,
 		protected key: string,

--- a/src/components/JSONSchema/Schema/ThenSchema.ts
+++ b/src/components/JSONSchema/Schema/ThenSchema.ts
@@ -38,13 +38,7 @@ export class ThenSchema extends Schema {
 		if (this.ifSchema.isTrue(obj)) {
 			const diagnostics = this.rootSchema.validate(obj)
 
-			if (diagnostics.length > 0)
-				return [
-					<const>{
-						severity: 'warning',
-						message: `Invalid "then" schema`,
-					},
-				]
+			return diagnostics
 		}
 		return []
 	}

--- a/src/components/JSONSchema/Schema/ThenSchema.ts
+++ b/src/components/JSONSchema/Schema/ThenSchema.ts
@@ -35,7 +35,17 @@ export class ThenSchema extends Schema {
 	}
 
 	validate(obj: unknown) {
-		if (this.ifSchema.isTrue(obj)) return this.rootSchema.validate(obj)
+		if (this.ifSchema.isTrue(obj)) {
+			const diagnostics = this.rootSchema.validate(obj)
+
+			if (diagnostics.length > 0)
+				return [
+					<const>{
+						severity: 'warning',
+						message: `Invalid "then" schema`,
+					},
+				]
+		}
 		return []
 	}
 }

--- a/src/components/JSONSchema/Schema/Type.ts
+++ b/src/components/JSONSchema/Schema/Type.ts
@@ -60,7 +60,7 @@ export class TypeSchema extends Schema {
 			return [
 				<const>{
 					severity: 'warning',
-					message: `Invalid type: Found ${valType}; expected ${values.join(
+					message: `This node is of type ${valType}; expected ${values.join(
 						', '
 					)}`,
 				},

--- a/src/components/JSONSchema/Schema/Type.ts
+++ b/src/components/JSONSchema/Schema/Type.ts
@@ -51,7 +51,8 @@ export class TypeSchema extends Schema {
 
 		if (!values.includes(getTypeOf(val)))
 			return [
-				{
+				<const>{
+					severity: 'error',
 					message: `Invalid type: Found ${getTypeOf(
 						val
 					)}; expected ${values.join(', ')}`,

--- a/src/components/JSONSchema/Schema/Type.ts
+++ b/src/components/JSONSchema/Schema/Type.ts
@@ -49,13 +49,20 @@ export class TypeSchema extends Schema {
 	validate(val: unknown) {
 		const values = Array.isArray(this.value) ? this.value : [this.value]
 
-		if (!values.includes(getTypeOf(val)))
+		// Every number is also an integer
+		if (values.includes('number') && !values.includes('integer')) {
+			values.push('integer')
+		}
+
+		let valType = getTypeOf(val)
+
+		if (!values.includes(valType))
 			return [
 				<const>{
-					severity: 'error',
-					message: `Invalid type: Found ${getTypeOf(
-						val
-					)}; expected ${values.join(', ')}`,
+					severity: 'warning',
+					message: `Invalid type: Found ${valType}; expected ${values.join(
+						', '
+					)}`,
 				},
 			]
 

--- a/src/components/Projects/Project/Project.ts
+++ b/src/components/Projects/Project/Project.ts
@@ -34,6 +34,7 @@ import { isUsingFileSystemPolyfill } from '../../FileSystem/Polyfill'
 import { iterateDir } from '/@/utils/iterateDir'
 import { Signal } from '../../Common/Event/Signal'
 import { moveHandle } from '/@/utils/file/moveHandle'
+import { TreeTab } from '../../Editors/TreeEditor/Tab'
 
 export interface IProjectData extends IConfigJson {
 	path: string
@@ -510,7 +511,9 @@ export abstract class Project {
 
 	async getFileFromDiskOrTab(filePath: string) {
 		const tab = await this.getFileTabWithPath(filePath)
-		if (tab && tab instanceof FileTab) return await tab.getFile()
+
+		if (tab instanceof FileTab || tab instanceof TreeTab)
+			return await tab.getFile()
 
 		return await this.app.fileSystem.readFile(filePath)
 	}

--- a/src/components/Windows/Settings/setupSettings.ts
+++ b/src/components/Windows/Settings/setupSettings.ts
@@ -456,6 +456,16 @@ export async function setupSettings(settings: SettingsWindow) {
 	settings.addControl(
 		new Toggle({
 			category: 'editor',
+			name: 'windows.settings.editor.inlineTreeEditorDiagnostics.name',
+			description:
+				'windows.settings.editor.inlineTreeEditorDiagnostics.description',
+			key: 'inlineTreeEditorDiagnostics',
+			default: true,
+		})
+	)
+	settings.addControl(
+		new Toggle({
+			category: 'editor',
 			name: 'windows.settings.editor.automaticallyOpenTreeNodes.name',
 			description:
 				'windows.settings.editor.automaticallyOpenTreeNodes.description',

--- a/src/components/Windows/Settings/setupSettings.ts
+++ b/src/components/Windows/Settings/setupSettings.ts
@@ -38,6 +38,15 @@ export async function setupSettings(settings: SettingsWindow) {
 		})
 	)
 	settings.addControl(
+		new Toggle({
+			category: 'appearance',
+			name: 'windows.settings.appearance.highContrast.name',
+			description: 'windows.settings.appearance.highContrast.description',
+			key: 'highContrast',
+			default: false,
+		})
+	)
+	settings.addControl(
 		new Selection({
 			category: 'appearance',
 			name: 'windows.settings.appearance.darkTheme.name',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1193,7 +1193,8 @@
 			"addArray": "Add Array",
 			"addValue": "Add Value",
 			"forceValue": "Force Value",
-			"edit": "Edit"
+			"edit": "Edit",
+			"childHasError": "One or more children have diagnostics"
 		},
 		"langValidation": {
 			"noValue": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -819,6 +819,10 @@
 					"name": "Color Scheme",
 					"description": "Choose the color scheme of bridge.'s UI"
 				},
+				"highContrast": {
+					"name": "High Contrast",
+					"description": "Enable high contrast mode"
+				},
 				"darkTheme": {
 					"name": "Dark Theme",
 					"description": "Select the default dark theme bridge. uses"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -962,6 +962,10 @@
 					"name": "Show Tree Editor Location Bar",
 					"description": "Allows you to quickly navigate your JSON file within the tree editor by displaying your current location above the editor."
 				},
+				"inlineTreeEditorDiagnostics": {
+					"name": "Inline Diagnostics",
+					"description": "Show diagnostic messages above the affected tree editor node"
+				},
 				"bridgePredictions": {
 					"name": "bridge. Predictions",
 					"description": "Enable bridge. predictions to let the app intelligently decide whether to add a value or object within bridge.'s tree editor. This simplifies editing JSON significantly"

--- a/src/utils/string/closestMatch.ts
+++ b/src/utils/string/closestMatch.ts
@@ -1,0 +1,17 @@
+import { editDistance } from './editDistance'
+
+/**
+ * Return the closest match to a string in a list of strings.
+ */
+export function closestMatch(
+	str: string,
+	strings: string[],
+	threshold = 0.3
+): string | null {
+	const distances = strings.map((s) => editDistance(str, s))
+	const min = Math.min(...distances)
+	const index = distances.findIndex((d) => d === min)
+	if (min / str.length > threshold) return null
+
+	return strings[index]
+}

--- a/src/utils/string/editDistance.ts
+++ b/src/utils/string/editDistance.ts
@@ -1,0 +1,36 @@
+/**
+ * Return the edit distance between two strings.
+ */
+export function editDistance(a: string, b: string): number {
+	if (a.length === 0) return b.length
+	if (b.length === 0) return a.length
+
+	const matrix = new Array(b.length + 1)
+	// Increment along the first column of each row
+	for (let i = 0; i <= b.length; i++) {
+		matrix[i] = new Array(a.length + 1)
+		matrix[i][0] = i
+	}
+
+	// Increment each column in the first row
+	for (let i = 0; i <= a.length; i++) {
+		matrix[0][i] = i
+	}
+
+	// Fill matrix
+	for (let i = 1; i <= b.length; i++) {
+		for (let j = 1; j <= a.length; j++) {
+			if (b.charAt(i - 1) === a.charAt(j - 1)) {
+				matrix[i][j] = matrix[i - 1][j - 1]
+			} else {
+				matrix[i][j] = Math.min(
+					matrix[i - 1][j - 1] + 1, // substitution
+					matrix[i][j - 1] + 1, // insertion
+					matrix[i - 1][j] + 1 // deletion
+				)
+			}
+		}
+	}
+
+	return matrix[b.length][a.length]
+}

--- a/src/utils/typeof.ts
+++ b/src/utils/typeof.ts
@@ -1,4 +1,10 @@
 export function getTypeOf(val: unknown) {
 	if (Array.isArray(val)) return 'array'
+	else if (val === null) return 'null'
+	else if (typeof val === 'number') {
+		if (Number.isInteger(val)) return 'integer'
+		else return 'number'
+	}
+
 	return typeof val
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,9 @@ module.exports = {
 			},
 			colors: {
 				primary: 'var(--v-primary-base)',
+				error: 'var(--v-error-base)',
+				warning: 'var(--v-warning-base)',
+				info: 'var(--v-info-base)',
 			},
 		},
 	},


### PR DESCRIPTION
## Description
This PR implements file validation for bridge. v2's tree editor based on JSON schemas.

## Motivation
closes #101 

## Additional Context
This PR additionally makes the following changes to improve the tree editor:
- Always select first auto-completion item for quicker typing
- Disable spellchecking and browser auto-complete within tree editor inputs
- Ensure auto-complete menu always opens below the inputs
- Properly support dynamic auto-completions for the current file within tree editor (e.g. events from the current file)

## Todos:
- [x] Figure out why file validation only kicks in after a first edit
- [x] Hover text for "error within child indicator"
- [x] Display error within context menu?
- [x] If schemas don't validate properly yet because we return the "then" content from the `getSchemasFor` function instead of the whole if statement
- [x] Clear parent diagnostics cache before validation
- [x] `doNotSuggest` is not working
- [x] Support for `deprecationMessage`
- [x] Format version error after removing `components` tree