### PR TITLE
fix: mobile users native app suggestion (#827)

### DIFF
--- a/src/components/PackExplorer/HomeView/SetupView.vue
+++ b/src/components/PackExplorer/HomeView/SetupView.vue
@@ -25,7 +25,7 @@
 		</BridgeSheet>
 
 		<BridgeSheet
-			v-if="!isTauriBuild"
+			v-if="!isMobile && !isTauriBuild"
 			dark
 			class="pa-2 mb-2 d-flex flex-column"
 			@click="openDownloadPage"
@@ -111,6 +111,11 @@ export default {
 			disposables: [],
 			actions: [],
 		}
+	},
+	computed: {
+		isMobile() {
+			return this.$vuetify.breakpoint.mobile
+		},
 	},
 	methods: {
 		async chooseEditor() {


### PR DESCRIPTION
## Description
Resolves #827 by removing the setup card, which tells users to install the native app if they're on a mobile device.  
## Motivation
- Limits the confusion regarding native apps
- Removes possible confusion about project syncing 
- Prevents duplicate install options from being displayed (install the app and native app)

## To Test
### Web App
- Run the web app and confirm that the install native app prompt appears
- Enter developer tools for your browser and change the viewport to a mobile device, confirm that the install native app prompt no longer appears
### Native build
- Confirm that the native app still does not prompt users to install the native app
