### PR TITLE
upd: bring back fuzzy search

### DIFF
--- a/src/components/Actions/SimpleAction.ts
+++ b/src/components/Actions/SimpleAction.ts
@@ -1,6 +1,7 @@
 import { IKeyBindingConfig } from './KeyBinding'
 import { EventDispatcher } from '/@/components/Common/Event/EventDispatcher'
 import { v4 as uuid } from 'uuid'
+import { translate } from '../Locales/Manager'
 
 export interface IActionConfig {
 	type?: 'action'
@@ -44,6 +45,13 @@ export class SimpleAction extends EventDispatcher<void> {
 		return this.config.isDisabled ?? false
 	}
 	//#endregion
+
+	get translatedName() {
+		return translate(this.name)
+	}
+	get translatedDescription() {
+		return translate(this.description)
+	}
 
 	getConfig() {
 		return this.config


### PR DESCRIPTION
## Description
This PR aims to re-introduce error tolerant search to bridge.'s command bar as I've noticed that we've accidentally deleted it

## Additional Context
https://github.com/bridge-core/editor/blob/v2.2.13/src/components/Windows/Project/FilePicker/FilePicker.vue

## Todos
- [ ] Command bar input is currently clearing after typing a character
