### PR TITLE
fix: extensions infinite loading

### DIFF
--- a/src/components/Notifications/warn.ts
+++ b/src/components/Notifications/warn.ts
@@ -1,0 +1,18 @@
+import { InformationWindow } from '../Windows/Common/Information/InformationWindow'
+import { createNotification } from './create'
+
+export function emitWarning(title: string, message: string) {
+	const notification = createNotification({
+		color: 'warning',
+		icon: 'mdi-alert',
+		message: title,
+		onClick: () => {
+			notification.dispose()
+
+			new InformationWindow({
+				description: message,
+				title: title,
+			})
+		},
+	})
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1004,6 +1004,11 @@
 				"title": "Downloaded Compiler Plugin",
 				"description": "You have just downloaded a new compiler plugin. Make sure to add it to your compiler config file or otherwise it won't have an effect.",
 				"openConfig": "Open Config"
+			},
+			"failedExtensionLoad": {
+				"title": "failed to load",
+				"description1": "The extension manifest",
+				"description2": "is invalid. Please consider contacting the extension author to fix this issue."
 			}
 		},
 		"pluginInstallLocation": {


### PR DESCRIPTION
## Description
This PR properly handles JSON errors within the extension manifest (emit warning and abort further processing) instead of throwing an error that would subsequently cause infinite loading when opening the extension store.

![Bildschirm­foto 2023-01-07 um 13 13 22](https://user-images.githubusercontent.com/33347616/211150171-7a1687df-12eb-4dde-b42c-64c9ceccae15.png)

## Motivation
closes #840
