### PR TITLE
feat: view bridge folder

### DIFF
--- a/src/components/Toolbar/Category/project.ts
+++ b/src/components/Toolbar/Category/project.ts
@@ -5,6 +5,8 @@ import { isUsingFileSystemPolyfill } from '/@/components/FileSystem/Polyfill'
 import { createVirtualProjectWindow } from '/@/components/FileSystem/Virtual/ProjectWindow'
 import { importNewProject } from '/@/components/Projects/Import/ImportNew'
 import { virtualProjectName } from '/@/components/Projects/Project/Project'
+import { revealInFileExplorer } from '/@/utils/revealInFileExplorer'
+import { getBridgeFolderPath } from '/@/utils/getBridgeFolderPath'
 
 export function setupProjectCategory(app: App) {
 	const project = new ToolbarCategory(
@@ -66,6 +68,18 @@ export function setupProjectCategory(app: App) {
 			onTrigger: () => importNewProject(),
 		})
 	)
+	if (import.meta.env.VITE_IS_TAURI_APP) {
+		project.addItem(
+			app.actionManager.create({
+				icon: 'mdi-folder-search-outline',
+				name: 'actions.viewBridgeFolder.name',
+				description: 'actions.viewBridgeFolder.description',
+				onTrigger: async () => {
+					revealInFileExplorer(await getBridgeFolderPath())
+				},
+			})
+		)
+	}
 	project.addItem(new Divider())
 
 	project.addItem(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -137,6 +137,10 @@
 	},
 	"actions": {
 		"name": "Actions",
+		"viewBridgeFolder": {
+			"name": "View bridge. Folder",
+			"description": "View the folder where bridge. stores your projects"
+		},
 		"about": {
 			"name": "About",
 			"description": "About bridge."

--- a/src/utils/getBridgeFolderPath.ts
+++ b/src/utils/getBridgeFolderPath.ts
@@ -1,4 +1,3 @@
-import { appLocalDataDir, join } from '@tauri-apps/api/path'
 import { get } from 'idb-keyval'
 
 let cachedPath: string | undefined = undefined
@@ -7,6 +6,8 @@ export async function getBridgeFolderPath() {
 	if (!import.meta.env.VITE_IS_TAURI_APP)
 		throw new Error(`This function is only available in Tauri apps.`)
 	if (cachedPath) return cachedPath
+
+	const { appLocalDataDir, join } = await import('@tauri-apps/api/path')
 
 	const configuredPath = await get<string | undefined>('bridgeFolderPath')
 	if (configuredPath) {


### PR DESCRIPTION
## Description
Allows quick access to the current bridge. folder without having to select a project first and then navigating a few levels up in the folder hierarchy.

![Bildschirm­foto 2023-01-07 um 14 01 11 1](https://user-images.githubusercontent.com/33347616/211151956-90de866e-3e1e-4a25-aed0-06ba46323030.png)
