### PR TITLE
upd(ComMojang): load projects lazily ahead of time

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -225,6 +225,9 @@ export class App {
 		if (import.meta.env.VITE_IS_TAURI_APP) {
 			// TauriFs env -> bridge. folder is the same as getStorageDirectory()
 			this.instance.bridgeFolderSetup.dispatch()
+			// Setup com.mojang folder
+			this.instance.comMojang.setupComMojang()
+
 			// Load projects
 			this.instance.projectManager.loadProjects(true)
 		}

--- a/src/components/Projects/ProjectChooser/ProjectChooser.ts
+++ b/src/components/Projects/ProjectChooser/ProjectChooser.ts
@@ -21,7 +21,7 @@ export class ProjectChooserWindow extends NewBaseWindow {
 	protected experimentalToggles: (IExperimentalToggle & {
 		isActive: boolean
 	})[] = []
-	protected comMojangProjectLoader
+	public readonly comMojangProjectLoader
 
 	protected state: IProjectChooserState = reactive<any>({
 		...super.getState(),

--- a/src/components/Projects/ProjectManager.ts
+++ b/src/components/Projects/ProjectManager.ts
@@ -199,6 +199,7 @@ export class ProjectManager extends Signal<void> {
 			)
 		}
 
+		// Setup com.mojang folder if necessary
 		if (!this.app.comMojang.hasFired && projectName !== virtualProjectName)
 			this.app.comMojang.setupComMojang()
 

--- a/src/components/Sidebar/setup.ts
+++ b/src/components/Sidebar/setup.ts
@@ -14,8 +14,15 @@ export async function setupSidebar() {
 		displayName: 'windows.projectChooser.title',
 		icon: 'mdi-view-dashboard-outline',
 		disabled: () =>
+			// Disable the projects chooser if...
+			// - We have no projects
 			App.instance.hasNoProjects &&
-			App.instance.bridgeFolderSetup.hasFired,
+			// - We have already setup the bridge folder
+			App.instance.bridgeFolderSetup.hasFired &&
+			// - We do not have com.mojang projects
+			!App.instance.windows.projectChooser.comMojangProjectLoader
+				.hasProjects.value,
+
 		onClick: async () => {
 			if (
 				App.instance.hasNoProjects &&


### PR DESCRIPTION
## Description
Load com.mojang projects lazily & ahead of time.

## Motivation
Previously, when the user had no bridge. project, they still couldn't access their com.mojang projects. Additionally, opening the project chooser with com.mojang projects now is faster.
