### PR TITLE
feat: launch minecraft

### DIFF
--- a/src/components/Toolbar/Category/project.ts
+++ b/src/components/Toolbar/Category/project.ts
@@ -47,6 +47,17 @@ export function setupProjectCategory(app: App) {
 			},
 		})
 	)
+	project.addItem(
+		app.actionManager.create({
+			icon: 'mdi-minecraft',
+			name: 'actions.launchMinecraft.name',
+			description: 'actions.launchMinecraft.description',
+			keyBinding: 'F5',
+			onTrigger: () => {
+				App.openUrl('minecraft:')
+			},
+		})
+	)
 	project.addItem(new Divider())
 
 	project.addItem(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -141,6 +141,10 @@
 			"name": "About",
 			"description": "About bridge."
 		},
+		"launchMinecraft": {
+			"name": "Launch Minecraft",
+			"description": "Launch Minecraft to test your projects"
+		},
 		"download": {
 			"name": "Download",
 			"description": "Download this file or folder"


### PR DESCRIPTION
## Description
Allows users to launch Minecraft using the menu action or by pressing `F5`. I think this is a nice convenience feature with little to no maintenance cost.

![Bildschirm­foto 2023-01-07 um 16 34 04](https://user-images.githubusercontent.com/33347616/211158547-3521c2e8-b181-4ab3-a7f6-986a9a7f22f2.png)
