### PR TITLE
Add open project folder in linux native app

### DIFF
--- a/src-tauri/src/fs_extra.rs
+++ b/src-tauri/src/fs_extra.rs
@@ -44,7 +44,10 @@ pub async fn reveal_in_file_explorer(path: &str) -> Result<(), String> {
             .spawn()
             .expect("Failed to open finder");
     } else {
-        // TODO: Linux
+        Command::new("xdg-open")
+            .args([path])
+            .spawn()
+            .expect("Failed to open file explorer");
     }
 
     Ok(())


### PR DESCRIPTION
I wrote this code based on the logic of the previous lines in the file, I must note that I know only a bit of Rust. Anyway this works on my machine. Maybe it should be modified to not default the OS to linux when it is unknown, and display some error message or the folder path to be copy/pasted, however I couldn't do that. I hope this help!