### PR TITLE
Native: Watches project and reloads project on file changes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "chrono",
  "discord-rich-presence",
  "mime_guess",
+ "notify",
  "serde",
  "serde_json",
  "tauri",
@@ -1030,6 +1031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,6 +1725,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +1862,26 @@ dependencies = [
  "serde_json",
  "thiserror",
  "treediff",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2057,6 +2107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -2130,6 +2181,25 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "notify-rust"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ window-shadows = "0.2.0"
 tokio = { version = "1.24", features = ["process", "io-util", "sync"] }
 mime_guess = "2.0.4"
 zip = "0.6"
+notify = "6.1.1"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,12 +3,16 @@
     windows_subsystem = "windows"
 )]
 
+use std::sync::Mutex;
+
+use notify::RecommendedWatcher;
 use tauri::{Manager, Menu};
 use terminal::AllTerminals;
 use window_shadows::set_shadow;
 mod discord;
 mod fs_extra;
 mod terminal;
+mod watch;
 mod zip;
 
 fn main() {
@@ -20,6 +24,7 @@ fn main() {
 
     tauri::Builder::default()
         .manage::<AllTerminals>(AllTerminals(Default::default()))
+        .manage::<Mutex<Option<RecommendedWatcher>>>(Mutex::new(None))
         .setup(|app| {
             // `main` here is the window label; it is defined under `tauri.conf.json`
             let main_window = app.get_window("main").unwrap();
@@ -43,6 +48,12 @@ fn main() {
                 }
             };
 
+            let watcher_state = app.state::<Mutex<Option<RecommendedWatcher>>>();
+
+            let mut watcher = watcher_state.lock().unwrap();
+
+            watcher.insert(watch::create_watcher(app.app_handle()));
+
             Ok(())
         })
         .menu(menu)
@@ -55,6 +66,8 @@ fn main() {
             terminal::kill_command,
             zip::unzip_command,
             zip::zip_command,
+            watch::watch_folder,
+            watch::unwatch_folder,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/watch.rs
+++ b/src-tauri/src/watch.rs
@@ -1,12 +1,36 @@
-use std::{path::Path, ptr::null, sync::Mutex};
+use std::{path::Path, sync::Mutex};
 
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use tauri::Manager;
 
 pub fn create_watcher(app_handle: tauri::AppHandle) -> RecommendedWatcher {
-    return notify::recommended_watcher(move |res| match res {
-        Ok(event) => {
-            app_handle.emit_all("watch_event", "event");
+    return notify::recommended_watcher(move |res: Result<notify::Event, _>| match res {
+        Ok(path) => {
+            let paths: Vec<String> = path
+                .paths
+                .iter()
+                .map(|p| {
+                    let full_path = p.to_str().unwrap();
+                    let app_data_path = app_handle
+                        .path_resolver()
+                        .app_local_data_dir()
+                        .unwrap()
+                        .join("bridge");
+                    let fixed_app_data_path = app_data_path.canonicalize().unwrap();
+                    let app_data_path_string = fixed_app_data_path.to_str().unwrap();
+                    let resolved_path = full_path.strip_prefix(app_data_path_string).unwrap();
+                    let mut normalized_path = resolved_path.replace("\\", "/");
+
+                    if normalized_path.starts_with("/") {
+                        normalized_path = normalized_path[1..].to_string();
+                    }
+
+                    return normalized_path;
+                })
+                .collect();
+
+            println!("watch event: {:?}", paths);
+            app_handle.emit_all("watch_event", paths).unwrap();
 
             return;
         }

--- a/src-tauri/src/watch.rs
+++ b/src-tauri/src/watch.rs
@@ -1,0 +1,64 @@
+use std::{path::Path, ptr::null, sync::Mutex};
+
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::Manager;
+
+pub fn create_watcher(app_handle: tauri::AppHandle) -> RecommendedWatcher {
+    return notify::recommended_watcher(move |res| match res {
+        Ok(event) => {
+            app_handle.emit_all("watch_event", "event");
+
+            return;
+        }
+        Err(e) => println!("watch error: {:?}", e),
+    })
+    .unwrap();
+}
+
+#[tauri::command]
+pub fn watch_folder(
+    path: String,
+    state: tauri::State<Mutex<Option<RecommendedWatcher>>>,
+    app_handle: tauri::AppHandle,
+) {
+    let resolved_path = app_handle
+        .path_resolver()
+        .app_local_data_dir()
+        .unwrap()
+        .join("bridge")
+        .join(Path::new(&path))
+        .canonicalize()
+        .unwrap();
+
+    println!("watching {:?}", resolved_path);
+
+    let mut watcher_option = state.lock().unwrap();
+    let watcher = watcher_option.as_mut().unwrap();
+
+    watcher
+        .watch(&resolved_path, RecursiveMode::Recursive)
+        .unwrap();
+}
+
+#[tauri::command]
+pub fn unwatch_folder(
+    path: String,
+    state: tauri::State<Mutex<Option<RecommendedWatcher>>>,
+    app_handle: tauri::AppHandle,
+) {
+    let resolved_path = app_handle
+        .path_resolver()
+        .app_local_data_dir()
+        .unwrap()
+        .join("bridge")
+        .join(Path::new(&path))
+        .canonicalize()
+        .unwrap();
+
+    println!("unwatch {:?}", resolved_path);
+
+    let mut watcher_option = state.lock().unwrap();
+    let watcher = watcher_option.as_mut().unwrap();
+
+    watcher.unwatch(&resolved_path).unwrap();
+}

--- a/src-tauri/src/watch.rs
+++ b/src-tauri/src/watch.rs
@@ -29,7 +29,6 @@ pub fn create_watcher(app_handle: tauri::AppHandle) -> RecommendedWatcher {
                 })
                 .collect();
 
-            println!("watch event: {:?}", paths);
             app_handle.emit_all("watch_event", paths).unwrap();
 
             return;
@@ -54,8 +53,6 @@ pub fn watch_folder(
         .canonicalize()
         .unwrap();
 
-    println!("watching {:?}", resolved_path);
-
     let mut watcher_option = state.lock().unwrap();
     let watcher = watcher_option.as_mut().unwrap();
 
@@ -78,8 +75,6 @@ pub fn unwatch_folder(
         .join(Path::new(&path))
         .canonicalize()
         .unwrap();
-
-    println!("unwatch {:?}", resolved_path);
 
     let mut watcher_option = state.lock().unwrap();
     let watcher = watcher_option.as_mut().unwrap();

--- a/src/App.ts
+++ b/src/App.ts
@@ -69,6 +69,7 @@ export class App {
 		'disableValidation',
 		'fileAdded',
 		'fileChange',
+		'beforeFileSave',
 		'fileSave',
 		'fileUnlinked',
 		'presetsChanged',

--- a/src/App.ts
+++ b/src/App.ts
@@ -74,6 +74,8 @@ export class App {
 		'fileUnlinked',
 		'presetsChanged',
 		'availableProjectsFileChanged',
+		'beforeModifiedProject',
+		'modifiedProject',
 	])
 	public static readonly ready = new Signal<App>()
 	protected static _instance: Readonly<App>

--- a/src/components/ImportFile/BasicFile.ts
+++ b/src/components/ImportFile/BasicFile.ts
@@ -114,12 +114,17 @@ export class BasicFileImporter extends FileImporter {
 			true
 		)
 
+		App.eventSystem.dispatch('beforeModifiedProject', null)
+
 		await app.project.fileSystem.copyFileHandle(fileHandle, destHandle)
 		App.eventSystem.dispatch('fileAdded', undefined)
 
 		await app.project.updateFile(
 			app.project.config.resolvePackPath(undefined, newFilePath)
 		)
+
+		App.eventSystem.dispatch('modifiedProject', null)
+
 		await app.project.openFile(destHandle, { isTemporary: false })
 
 		app.windows.loadingWindow.close()

--- a/src/components/PackIndexer/PackIndexer.ts
+++ b/src/components/PackIndexer/PackIndexer.ts
@@ -100,6 +100,7 @@ export class PackIndexer extends Signal<[string[], string[]]> {
 		await this.isPackIndexerFree.lock()
 
 		await this.service.updatePlugins(App.fileType.getPluginFileTypes())
+
 		const anyFileChanged = await this.service.updateFile(
 			filePath,
 			fileContent,

--- a/src/components/Projects/Project/Project.ts
+++ b/src/components/Projects/Project/Project.ts
@@ -280,7 +280,7 @@ export abstract class Project {
 
 		this.snippetLoader.activate()
 
-		if (!this.isVirtualProject)
+		if (!this.isVirtualProject && import.meta.env.VITE_IS_TAURI_APP)
 			await invoke('watch_folder', { path: this.projectPath })
 	}
 
@@ -297,7 +297,7 @@ export abstract class Project {
 			this.snippetLoader.deactivate(),
 		])
 
-		if (!this.isVirtualProject)
+		if (!this.isVirtualProject && import.meta.env.VITE_IS_TAURI_APP)
 			await invoke('unwatch_folder', { path: this.projectPath })
 	}
 	dispose() {

--- a/src/components/Projects/Project/Project.ts
+++ b/src/components/Projects/Project/Project.ts
@@ -170,12 +170,14 @@ export abstract class Project {
 		this.fileChange.any.on((data) =>
 			App.eventSystem.dispatch('fileChange', data)
 		)
-		this.beforeFileSave.any.on((data) =>
+		this.beforeFileSave.any.on((data) => {
 			App.eventSystem.dispatch('beforeFileSave', data)
-		)
-		this.fileSave.any.on((data) =>
+			App.eventSystem.dispatch('beforeModifiedProject', null)
+		})
+		this.fileSave.any.on((data) => {
 			App.eventSystem.dispatch('fileSave', data)
-		)
+			App.eventSystem.dispatch('modifiedProject', null)
+		})
 		this.fileUnlinked.any.on((data) =>
 			App.eventSystem.dispatch('fileUnlinked', data[0])
 		)

--- a/src/components/Projects/Project/Project.ts
+++ b/src/components/Projects/Project/Project.ts
@@ -35,6 +35,7 @@ import { iterateDir } from '/@/utils/iterateDir'
 import { Signal } from '../../Common/Event/Signal'
 import { moveHandle } from '/@/utils/file/moveHandle'
 import { TreeTab } from '../../Editors/TreeEditor/Tab'
+import { invoke } from '@tauri-apps/api'
 
 export interface IProjectData extends IConfigJson {
 	path: string
@@ -273,7 +274,11 @@ export abstract class Project {
 		])
 
 		this.snippetLoader.activate()
+
+		if (!this.isVirtualProject)
+			invoke('watch_folder', { path: this.projectPath })
 	}
+
 	async deactivate(isReload = false) {
 		if (!isReload)
 			this.tabSystems.forEach((tabSystem) => tabSystem.deactivate())
@@ -286,6 +291,9 @@ export abstract class Project {
 			this.packIndexer.deactivate(),
 			this.snippetLoader.deactivate(),
 		])
+
+		if (!this.isVirtualProject)
+			invoke('unwatch_folder', { path: this.projectPath })
 	}
 	dispose() {
 		this.tabSystems.forEach((tabSystem) => tabSystem.dispose())

--- a/src/components/Projects/ProjectManager.ts
+++ b/src/components/Projects/ProjectManager.ts
@@ -15,6 +15,7 @@ import { v4 as uuid } from 'uuid'
 import { ICreateProjectOptions } from './CreateProject/CreateProject'
 import { InformationWindow } from '../Windows/Common/Information/InformationWindow'
 import { isUsingFileSystemPolyfill } from '../FileSystem/Polyfill'
+import { listen } from '@tauri-apps/api/event'
 
 export class ProjectManager extends Signal<void> {
 	public readonly addedProject = new EventDispatcher<Project>()
@@ -28,6 +29,11 @@ export class ProjectManager extends Signal<void> {
 		super()
 		// Only load local projects on PWA builds
 		if (!import.meta.env.VITE_IS_TAURI_APP) this.loadProjects()
+
+		listen('watch_event', this.handleWatchEvent)
+		App.eventSystem.on('fileAdded', this.handleFileChangeEvent)
+		App.eventSystem.on('fileUnlinked', this.handleFileChangeEvent)
+		App.eventSystem.on('fileSave', this.handleFileChangeEvent)
 	}
 
 	get currentProject() {
@@ -329,5 +335,15 @@ export class ProjectManager extends Signal<void> {
 			newData
 		)
 		App.eventSystem.dispatch('availableProjectsFileChanged', undefined)
+	}
+	async handleFileChangeEvent(event: any) {
+		console.log(event)
+	}
+	async handleWatchEvent(event: any) {
+		const app = await App.getApp()
+
+		console.log(event)
+
+		// app.actionManager.trigger('bridge.action.refreshProject')
 	}
 }

--- a/src/components/TabSystem/TabSystem.ts
+++ b/src/components/TabSystem/TabSystem.ts
@@ -282,6 +282,11 @@ export class TabSystem extends MonacoHolder {
 		if (selectedTab !== tab) await this.select(selectedTab)
 
 		if (!tab.isForeignFile && tab instanceof FileTab) {
+			this.project.beforeFileSave.dispatch(
+				tab.getPath(),
+				await tab.getFile()
+			)
+
 			await this.project.updateFile(tab.getPath())
 
 			this.project.fileSave.dispatch(tab.getPath(), await tab.getFile())

--- a/src/components/UIElements/DirectoryViewer/ContextMenu/Actions/Edit/Paste.ts
+++ b/src/components/UIElements/DirectoryViewer/ContextMenu/Actions/Edit/Paste.ts
@@ -22,6 +22,8 @@ export const PasteAction = (directoryWrapper: DirectoryWrapper) => ({
 
 		if (!directoryWrapper.isOpen.value) await directoryWrapper.open()
 
+		App.eventSystem.dispatch('beforeModifiedProject', null)
+
 		let newHandle: AnyHandle
 		if (handleToPaste.kind === 'file') {
 			const newName = await findSuitableFileName(
@@ -55,6 +57,9 @@ export const PasteAction = (directoryWrapper: DirectoryWrapper) => ({
 
 		await directoryWrapper.refresh()
 		if (newHandle) await project.updateHandle(newHandle)
+
+		App.eventSystem.dispatch('modifiedProject', null)
+
 		return newHandle
 	},
 })


### PR DESCRIPTION
## Description
Uses rust to watch for filesystem updates in the selected project, then triggering a project refresh.

## Motivation
This prevents the need to refresh the project when files are modified using external editors.