### PR TITLE
Add a warning when turning on HCF that it will be removed soon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "bridge",
-	"version": "2.7.14",
+	"version": "2.7.20",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bridge",
-			"version": "2.7.14",
+			"version": "2.7.20",
 			"dependencies": {
 				"@mdi/font": "^6.9.96",
 				"@tauri-apps/api": "^1.2.0",

--- a/src/components/Projects/CreateProject/ExperimentalGameplay.vue
+++ b/src/components/Projects/CreateProject/ExperimentalGameplay.vue
@@ -56,9 +56,9 @@ export default {
 			if (this.experiment.id == 'holidayCreatorFeatures') {
 				if (this.value == false) return
 				new InformationWindow({
-					title: 'Upcoming Deprecation',
+					title: 'experimentalGameplay.experimentDeprecation.title',
 					description:
-						'Holiday Creator Features will be deprecated in the future.',
+						'experimentalGameplay.experimentDeprecation.hcfDescription',
 				})
 			}
 		},

--- a/src/components/Projects/CreateProject/ExperimentalGameplay.vue
+++ b/src/components/Projects/CreateProject/ExperimentalGameplay.vue
@@ -1,10 +1,9 @@
 <template>
 	<ToggleSheet
 		:value="value"
-		@input="$emit('input', $event)"
+		@input="onClick"
 		:dark="true"
 		:isToggleable="isToggleable"
-		@click.native="onClick"
 	>
 		<template #default="{ value }">
 			<div class="d-flex align-center">
@@ -53,10 +52,12 @@ export default {
 		isInProjectChooser: Boolean,
 	},
 	methods: {
-		onClick() {
+		onClick(value) {
+			this.$emit('input', value)
+
 			if (this.experiment.id == 'holidayCreatorFeatures') {
-				if (this.isInProjectChooser && this.value) return
-				if (!this.isInProjectChooser && !this.value) return
+				if (!value) return
+
 				new InformationWindow({
 					title: 'experimentalGameplay.experimentDeprecation.title',
 					description:

--- a/src/components/Projects/CreateProject/ExperimentalGameplay.vue
+++ b/src/components/Projects/CreateProject/ExperimentalGameplay.vue
@@ -4,6 +4,7 @@
 		@input="$emit('input', $event)"
 		:dark="true"
 		:isToggleable="isToggleable"
+		@click.native="onClick"
 	>
 		<template #default="{ value }">
 			<div class="d-flex align-center">
@@ -29,6 +30,7 @@
 import ToggleSheet from '/@/components/UIElements/ToggleSheet.vue'
 import SelectedStatus from '/@/components/UIElements/SelectedStatus.vue'
 import { TranslationMixin } from '/@/components/Mixins/TranslationMixin'
+import { InformationWindow } from '../../Windows/Common/Information/InformationWindow'
 
 export default {
 	name: 'ExperimentalGameplay',
@@ -48,6 +50,18 @@ export default {
 		},
 		value: Boolean,
 		dense: Boolean,
+	},
+	methods: {
+		onClick() {
+			if (this.experiment.id == 'holidayCreatorFeatures') {
+				if (this.value == false) return
+				new InformationWindow({
+					title: 'Upcoming Deprecation',
+					description:
+						'Holiday Creator Features will be deprecated in the future.',
+				})
+			}
+		},
 	},
 }
 </script>

--- a/src/components/Projects/CreateProject/ExperimentalGameplay.vue
+++ b/src/components/Projects/CreateProject/ExperimentalGameplay.vue
@@ -50,11 +50,13 @@ export default {
 		},
 		value: Boolean,
 		dense: Boolean,
+		isInProjectChooser: Boolean,
 	},
 	methods: {
 		onClick() {
 			if (this.experiment.id == 'holidayCreatorFeatures') {
-				if (this.value == false) return
+				if (this.isInProjectChooser && this.value) return
+				if (!this.isInProjectChooser && !this.value) return
 				new InformationWindow({
 					title: 'experimentalGameplay.experimentDeprecation.title',
 					description:

--- a/src/components/Projects/ProjectChooser/ProjectChooser.vue
+++ b/src/components/Projects/ProjectChooser/ProjectChooser.vue
@@ -139,6 +139,7 @@
 							:experiment="experiment"
 							:isToggleable="true"
 							:value="experiment.isActive"
+							:isInProjectChooser="true"
 							@click.native="onToggleExperiment(experiment)"
 							style="height: 100%"
 						/>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -588,6 +588,10 @@
 		}
 	},
 	"experimentalGameplay": {
+		"experimentDeprecation": {
+			"title": "Upcoming Experiment Deprecation",
+			"hcfDescription": "The Holiday Creator Features experiment will be removed in 1.21.20, block and item events will be replaced with custom components."
+		},
 		"cavesAndCliffs": {
 			"name": "Caves and Cliffs",
 			"description": "Enables auto-completions for the new mountain generation inside of biomes."
@@ -953,7 +957,6 @@
 					"name": "JSON Editor",
 					"description": "Choose how you want to edit JSON files"
 				},
-
 				"bracketPairColorization": {
 					"name": "Bracket Pair Colorization",
 					"description": "Give matching brackets an unique color"


### PR DESCRIPTION
## Description
When a user toggles the HCF experiment an information box will appear letting them know that HCF will be removed in 1.21.20.
## Motivation
HCF is being removed and content using it will break. Bridge. can help spread the word about it's impending removal.
