### PR TITLE
[v3] i18n: Update ja.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "bridge",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bridge",
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"dependencies": {
 				"@bridge-editor/dash-compiler": "^0.13.0-beta",
 				"@bridge-editor/js-runtime": "^0.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "bridge",
-	"version": "3.0.2",
+	"version": "3.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bridge",
-			"version": "3.0.2",
+			"version": "3.0.1",
 			"dependencies": {
 				"@bridge-editor/dash-compiler": "^0.13.0-beta",
 				"@bridge-editor/js-runtime": "^0.6.2",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -16,7 +16,7 @@
 		"skip": "スキップ",
 		"save": "保存",
 		"shareFile": "共有",
-		"more": "もっと...",
+		"more": "もっと",
 		"selectFolder": "フォルダーを選択",
 		"fileName": "ファイル名",
 		"folderName": "フォルダー名",
@@ -78,18 +78,6 @@
 		}
 	},
 	"fileType": {
-		"aimAssistCategories": "エイムアシストカテゴリー",
-		"aimAssistPreset": "エイムアシストプリセット",
-		"atmosphereSettings": "雰囲気設定",
-		"blockCulling": "ブロックカリング",
-		"cameraPreset": "カメラプリセット",
-		"craftingItemCatalog": "クラフティングアイテムカタログ",
-		"colorGradingSettings": "カラーグレーディング設定",
-		"dimension": "ディメンション",
-		"splashes": "水しぶき",
-		"shadowSettings": "シャドウ設定",
-		"structureSet": "ストラクチャーセット",
-		"templatePool": "テンプレートプール",
 		"manifest": "マニフェスト",
 		"animation": "アニメーション",
 		"animationController": "アニメーションコントローラー",
@@ -145,292 +133,374 @@
 		"simpleFile": "シンプルファイル",
 		"ui": "UI",
 		"volume": "ボリューム",
-		"worldManifest": "ワールドマニフェスト"
+		"worldManifest": "ワールドマニフェスト",
+		"aimAssistCategories": "エイムアシストのカテゴリ",
+		"aimAssistPreset": "エイムアシストプリセット",
+		"atmosphereSettings": "雰囲気設定",
+		"biomesClient": "バイオームクライアント",
+		"blockCulling": "ブロックカリング",
+		"cameraPreset": "カメラのプリセット",
+		"colorGradingSettings": "カラーグレーディング設定",
+		"craftingItemCatalog": "クラフトアイテムカタログ",
+		"dimension": "寸法",
+		"jigsawStructure": "ジグソー構造",
+		"lightingSettings": "照明設定",
+		"pbrFallbackSettings": "PBR フォールバック設定",
+		"pointLightSettings": "ポイントライトの設定",
+		"processorList": "プロセッサーリスト",
+		"shadowSettings": "影の設定",
+		"splashes": "水しぶき",
+		"structureSet": "構造セット",
+		"templatePool": "テンプレートプール",
+		"waterSettings": "水の設定"
 	},
 	"actions": {
 		"name": "アクション",
-		"viewBridgeFolder": {
-			"name": "bridge. フォルダーを見る",
-			"description": "bridge. がプロジェクトを保存しているフォルダーを表示する"
-		},
-		"about": {
-			"name": "About",
-			"description": "bridge. について"
-		},
-		"launchMinecraft": {
-			"name": "Minecraftを起動",
-			"description": "Minecraftを起動し、プロジェクトをテストする"
-		},
-		"download": {
-			"name": "ダウンロード",
-			"description": "このファイルまたはフォルダーをダウンロードする"
-		},
-		"fullscreen": {
-			"name": "全画面表示",
-			"description": "全画面表示を切り替えます"
-		},
-		"viewConnectedFiles": {
-			"name": "ファイル内のコンテンツを見る",
-			"description": "ファイル内のコンテンツをすべて見る"
-		},
-		"viewExtensionsFolder": {
-			"name": "拡張機能フォルダーを表示する",
-			"description": "bridge. がグローバル拡張機能を保存しているフォルダーを表示します。"
-		},
-		"open": {
-			"name": "開く",
-			"description": "エディターでファイルを開く"
-		},
-		"openWith": {
-			"name": "開く...",
-			"description": "エディターでファイルを開く"
-		},
-		"openInSplitScreen": {
-			"name": "分割画面で開く",
-			"description": "ファイルを分割画面で開く"
-		},
-		"edit": {
-			"name": "編集",
-			"description": "ファイルまたはフォルダーを編集する"
-		},
-		"delete": {
-			"name": "削除",
-			"description": "ファイルやフォルダーを削除する",
-			"confirmText": "本当に削除しますか?",
-			"noRestoring": "後からファイルを復元することはできません"
-		},
-		"rename": {
-			"name": "名前の変更",
-			"description": "ファイル名の変更",
-			"sameName": "新しいファイル名は大文字と小文字が異なるだけです。 Windowsではサポートされません。"
-		},
-		"duplicate": {
-			"name": "複製",
-			"description": "ファイルを複製する"
-		},
-		"viewCompilerOutput": {
-			"name": "コンパイラの出力表示",
-			"view": "コンパイラの出力を見る",
-			"description": "このファイルのコンパイラ出力を表示する",
-			"fileMissing": "このファイルはまだコンパイルされていません"
-		},
-		"revealPath": {
-			"name": "ファイルパスの表示",
-			"description": "ファイルやフォルダーの場所を表示する"
-		},
-		"revealInFileExplorer": {
-			"name": "エクスプローラーで表示する",
-			"description": "ファイルエクスプローラーでファイルやフォルダーの場所を表示します。"
-		},
-		"createFile": {
-			"name": "新しいファイル",
-			"description": "新規ファイル作成"
-		},
-		"importFile": {
-			"name": "ファイルのインポート"
-		},
-		"createFolder": {
-			"name": "新しいフォルダー",
-			"description": "新規フォルダー作成"
-		},
-		"findInFolder": {
-			"name": "フォルダー内検索",
-			"description": "フォルダー内を検索する"
-		},
-		"goHome": {
-			"name": "ホームへ戻る",
-			"description": "ホーム画面へ戻る"
-		},
-		"newProject": {
-			"name": "新規プロジェクト",
-			"description": "新規 bridge. プロジェクトを作成します"
-		},
-		"newFile": {
-			"name": "新規ファイル",
-			"description": "新しいアドオン機能の作成"
-		},
-		"openFile": {
-			"name": "ファイルを開く",
-			"description": "現在のプロジェクトからファイルを開く"
-		},
-		"openFolder": {
-			"name": "フォルダーを開く",
-			"description": "フォルダーを開いて編集したり、出力フォルダーとして設定したり、その他のアクションを起動することができます。"
-		},
-		"searchFile": {
-			"name": "ファイルを探す",
-			"description": "現在のプロジェクトからファイルを検索して開く"
-		},
-		"saveFile": {
-			"name": "ファイルを保存",
-			"description": "現在開いているファイルを保存する"
-		},
-		"saveAs": {
-			"name": "名前を付けて保存...",
-			"description": "現在開いているファイルを別の名前で保存する"
-		},
-		"saveAll": {
-			"name": "すべて保存",
-			"description": "現在開いているファイルをすべて保存"
-		},
-		"closeFile": {
-			"name": "ファイルを閉じる",
-			"description": "現在開いているファイルを閉じる"
-		},
-		"settings": {
-			"name": "設定",
-			"description": "bridge. のアプリ設定を開く"
-		},
-		"extensions": {
-			"name": "拡張機能",
-			"description": "拡張機能のインストールと管理"
-		},
-		"copy": {
-			"name": "コピー",
-			"description": "選択したテキストをクリップボードにコピー"
-		},
-		"cut": {
-			"name": "切り取り",
-			"description": "選択したテキストをクリップボードにコピーして切り取る"
-		},
-		"paste": {
-			"name": "貼り付け",
-			"description": "クリップボードの内容を貼り付ける"
-		},
-		"docs": {
-			"name": "ドキュメント",
-			"description": "Minecraft アドオンのドキュメントを開く"
-		},
-		"minecraftDocs": {
-			"name": "Minecraft ドキュメント",
-			"description": "Minecraft Bedrock Add-Onのドキュメントを開く"
-		},
-		"releases": {
-			"name": "リリース",
-			"description": "最新の bridge. リリースを見る"
-		},
-		"bugReports": {
-			"name": "バグレポート",
-			"description": "bridge. の問題を報告する"
-		},
-		"twitter": {
-			"name": "Twitter",
-			"description": "Twitter で bridge. をフォローする"
-		},
-		"extensionAPI": {
-			"name": "拡張機能 API",
-			"description": "bridge. の拡張機能 API について詳しくはこちら"
-		},
-		"gettingStarted": {
-			"name": "はじめに",
-			"description": "bridge. を使い始めるためのガイドを読む"
-		},
-		"faq": {
-			"name": "FAQ",
-			"description": "bridge. でのアドオン開発に関するよくある質問"
-		},
-		"reloadAutoCompletions": {
-			"name": "オートコンプリートの再読み込み",
-			"description": "すべてのオートコンプリートデータを再読み込みする"
-		},
-		"reloadExtensions": {
-			"name": "拡張機能の再読み込み",
-			"description": "すべての拡張機能を再読み込みする"
-		},
-		"moveToSplitScreen": {
-			"name": "分割画面へ移動",
-			"description": "分割画面を開きこのタブを移す"
-		},
-		"closeTab": {
-			"name": "タブを閉じる",
-			"description": "このタブを閉じる"
-		},
-		"closeAll": {
-			"name": "すべて閉じる",
-			"description": "すべてのタブを閉じる"
-		},
-		"closeTabsToRight": {
-			"name": "右側を閉じる",
-			"description": "このタブの右側にあるすべてのタブを閉じる"
-		},
-		"closeAllSaved": {
-			"name": "保存済みを閉じる",
-			"description": "保存したタブをすべて閉じる"
-		},
-		"closeOtherTabs": {
-			"name": "その他を閉じる",
-			"description": "このタブ以外のすべてのタブを閉じる"
-		},
-		"clearAllNotifications": {
-			"name": "すべての通知を消去",
-			"description": "現在表示されているすべての通知を消去する"
-		},
-		"pluginInstallLocation": {
-			"global": {
-				"name": "グローバルにインストール",
-				"description": "すべてのプロジェクトで利用可能にします"
+		"dash": {
+			"compileDefault": {
+				"name": "Dash",
+				"description": "プロジェクトの「config.json」ファイルに含まれるデフォルトのコンパイラ設定で、 bridge.のコンパイラを実行します"
 			},
-			"local": {
-				"name": "ローカルにインストール",
-				"description": "追加したプロジェクトの中でのみ利用可能にします"
+			"name": "Dash"
+		},
+		"editor": {
+			"clearNotifications": {
+				"name": "通知を消去",
+				"description": "サイドバーの通知をすべて消去します"
+			},
+			"closeTab": {
+				"name": "タブを閉じる",
+				"description": "このタブを閉じる"
+			},
+			"extensions": {
+				"name": "拡張機能",
+				"description": "拡張機能のインストールと管理"
+			},
+			"goHome": {
+				"name": "ホームへ戻る",
+				"description": "ホーム画面へ戻る"
+			},
+			"importProject": {
+				"name": "プロジェクトのインポート",
+				"description": "新しいプロジェクトをインポートする"
+			},
+			"launchMinecraft": {
+				"name": "Minecraftを起動",
+				"description": "プロジェクトをテストするためにMinecraftを起動してください"
+			},
+			"name": "Editor",
+			"nextTab": {
+				"name": "次のタブ",
+				"description": "次のタブに切り替える"
+			},
+			"openFolder": {
+				"name": "フォルダーを開く",
+				"description": "フォルダーを開いて編集したり、出力フォルダーとして設定したり、その他のアクションを起動することができます。"
+			},
+			"previousTab": {
+				"name": "前のタブ",
+				"description": "前のタブに切り替える"
+			},
+			"reloadEditor": {
+				"name": "エディターを再読み込み",
+				"description": "エディターを再起動します。保存していない変更はすべて失われます"
+			},
+			"revealBridgeFolder": {
+				"name": "bridge. フォルダーを開く",
+				"description": "システムのファイルエクスプローラーでbridge. フォルダーを開きます"
+			},
+			"revealExtensionsFolder": {
+				"name": "拡張機能フォルダーを開く",
+				"description": "システムのファイルエクスプローラーでbridge. の拡張機能フォルダーを開きます。"
+			},
+			"revealOutputFolder": {
+				"name": "出力フォルダーを開く",
+				"description": "システムのファイルエクスプローラーで現在の出力フォルダーを開きます"
+			},
+			"settings": {
+				"name": "設定",
+				"description": "設定ウィンドウを開きます"
 			}
 		},
-		"toObject": {
-			"name": "オブジェクトに変換"
+		"textEditor": {
+			"name": "テキストエディタ",
+			"undo": {
+				"name": "元に戻す",
+				"description": "最後の操作を元に戻します"
+			},
+			"redo": {
+				"name": "やり直し",
+				"description": "元に戻した操作を再実行します"
+			},
+			"copy": {
+				"name": "コピー",
+				"description": "選択したテキストをクリップボードにコピーします"
+			},
+			"cut": {
+				"name": "切り取り",
+				"description": "選択したテキストをコピーして削除します"
+			},
+			"paste": {
+				"name": "貼り付け",
+				"description": "クリップボードの内容を貼り付けます"
+			},
+			"goToDefinition": {
+				"name": "定義へ移動",
+				"description": "選択したシンボルの定義へ移動します"
+			},
+			"goToSymbol": {
+				"name": "シンボルへ移動",
+				"description": "移動先のシンボルを選択するダイアログを開きます"
+			},
+			"formatDocument": {
+				"name": "ドキュメントの整形",
+				"description": "現在開いているドキュメントを整形します"
+			},
+			"changeAllOccurrences": {
+				"name": "すべての出現箇所を変更",
+				"description": "選択したテキストがあるすべての箇所を変更します"
+			},
+			"documentationLookup": {
+				"name": "ドキュメントを表示",
+				"description": "関連するドキュメントを開きます"
+			}
 		},
-		"toArray": {
-			"name": "配列に変換"
+		"treeEditor": {
+			"name": "ツリーエディタ",
+			"undo": {
+				"name": "元に戻す",
+				"description": "最後の操作を元に戻します"
+			},
+			"redo": {
+				"name": "やり直し",
+				"description": "元に戻した操作を再実行します"
+			},
+			"copy": {
+				"name": "コピー",
+				"description": "選択した内容をクリップボードにコピーします"
+			},
+			"cut": {
+				"name": "切り取り",
+				"description": "選択した内容をコピーして削除します"
+			},
+			"paste": {
+				"name": "貼り付け",
+				"description": "クリップボードの内容を貼り付けます"
+			},
+			"delete": {
+				"name": "削除",
+				"description": "選択した内容を削除します"
+			},
+			"convertToObject": {
+				"name": "オブジェクトに変換",
+				"description": "選択した値をオブジェクトに変換します"
+			},
+			"convertToArray": {
+				"name": "配列に変換",
+				"description": "選択した値を配列に変換します"
+			},
+			"convertToNull": {
+				"name": "null に変換",
+				"description": "選択した値を null に変換します"
+			},
+			"convertToNumber": {
+				"name": "数値に変換",
+				"description": "選択した値を数値に変換します"
+			},
+			"convertToString": {
+				"name": "文字列に変換",
+				"description": "選択した値を文字列に変換します"
+			},
+			"convertToBoolean": {
+				"name": "真偽値に変換",
+				"description": "選択した値を true/false に変換します"
+			},
+			"documentationLookup": {
+				"name": "ドキュメントを表示",
+				"description": "関連するドキュメントを開きます"
+			}
 		},
-		"documentationLookup": {
-			"name": "ドキュメントの表示",
-			"noDocumentation": "このドキュメントはありません: "
+		"export": {
+			"brproject": {
+				"name": "bridge. プロジェクトとしてエクスポート",
+				"description": "現在のプロジェクトを.brprojectとしてエクスポートする"
+			},
+			"mcaddon": {
+				"name": "Add-On としてエクスポート",
+				"description": "現在のプロジェクトを.mcaddonとしてエクスポートする"
+			},
+			"mctemplate": {
+				"name": "ワールドテンプレートとしてエクスポート",
+				"description": "現在のプロジェクトをワールトテンプレートとしてエクスポートする"
+			},
+			"mcworld": {
+				"name": "ワールドとしてエクスポート",
+				"description": "現在のプロジェクトを.mcworldとしてエクスポートする"
+			},
+			"name": "エクスポート"
 		},
-		"toggleReadOnly": {
-			"name": "読み取り専用の切り替え",
-			"description": "現在開いているファイルの読み取り専用モードを切り替える"
+		"files": {
+			"copy": {
+				"name": "コピー",
+				"description": "選択したテキストをクリップボードにコピー"
+			},
+			"createFile": {
+				"name": "ファイルを作成する",
+				"description": "新規ファイル作成"
+			},
+			"createFolder": {
+				"name": "フォルダーを作成する",
+				"description": "新規フォルダー作成"
+			},
+			"delete": {
+				"name": "削除",
+				"description": "ファイルやフォルダーを削除する"
+			},
+			"duplicate": {
+				"name": "複製",
+				"description": "ファイルやフォルダーを複製する"
+			},
+			"name": "ファイル",
+			"openToSide": {
+				"name": "サイドに開く",
+				"description": "ファイルをサイドウィンドウで開く"
+			},
+			"paste": {
+				"name": "貼り付け",
+				"description": "クリップボードの内容を貼り付ける"
+			},
+			"rename": {
+				"name": "名前の変更",
+				"description": "ファイルやフォルダー名の変更"
+			},
+			"revealInFileExplorer": {
+				"name": "エクスプローラーで表示する",
+				"description": "ファイルエクスプローラーでファイルやフォルダーの場所を表示します。"
+			},
+			"save": {
+				"name": "保存",
+				"description": "現在のファイルを保存する"
+			},
+			"saveAll": {
+				"name": "すべて保存",
+				"description": "現在開いているファイルをすべて保存する"
+			},
+			"saveAs": {
+				"name": "名前を付けて保存...",
+				"description": "現在開いているファイルを別の名前で保存する"
+			}
 		},
-		"keepInTabSystem": {
-			"name": "タブを固定",
-			"description": "タブを固定します"
+		"help": {
+			"bedrockDevDocs": {
+				"name": "bedrock.dev ドキュメント",
+				"description": "bedrock.dev ドキュメントを新しいブラウザタブで開きます"
+			},
+			"creatorDocs": {
+				"name": "Minecraft クリエイタードキュメント",
+				"description": "Minecraft クリエイター向けドキュメントを新しいブラウザタブで開きます"
+			},
+			"download": {
+				"name": "ダウンロード",
+				"description": "bridge. のネイティブアプリをダウンロードするためのガイドを開きます"
+			},
+			"extensions": {
+				"name": "拡張機能",
+				"description": "bridge. の拡張機能の作り方を新しいブラウザタブで開きます"
+			},
+			"faq": {
+				"name": "FAQ",
+				"description": "bridge. でのアドオン開発に関するよくある質問を新しいブラウザタブで開きます"
+			},
+			"feedback": {
+				"name": "フィードバックとバグ報告",
+				"description": "GitHubでIssueを開く"
+			},
+			"gettingStarted": {
+				"name": "はじめに",
+				"description": "bridge. を使い始めるためのガイドを読む"
+			},
+			"name": "ヘルプ",
+			"openChangelog": {
+				"name": "チェンジログを開く",
+				"description": "現在のバージョンのbridge. のチェンジログを開きます"
+			},
+			"releases": {
+				"name": "リリース",
+				"description": "最新の bridge. リリースを見る"
+			},
+			"scriptingDocs": {
+				"name": "Script API ドキュメント",
+				"description": "Minecraft Script API ドキュメントを新しいブラウザタブで開きます"
+			}
 		},
-		"importBrproject": {
-			"name": "プロジェクトのインポート",
-			"description": ".brproject ファイルからプロジェクトをインポートする"
+		"misc": {
+			"name": "その他"
 		},
-		"downloadFile": {
-			"name": "ファイルをダウンロード",
-			"description": "現在開いているファイルをダウンロードする"
+		"more": "もっと",
+		"project": {
+			"importFile": {
+				"name": "ファイルをインポート",
+				"description": "プロジェクトにファイルをインポートする"
+			},
+			"name": "プロジェクト",
+			"newProject": {
+				"name": "新規プロジェクト",
+				"description": "プロジェクト作成ダイアログを開く"
+			},
+			"reload": {
+				"name": "プロジェクトを再読み込み",
+				"description": "現在読み込まれているプロジェクトを再読み込みします"
+			},
+			"reloadExtensions": {
+				"name": "拡張機能を再読み込み",
+				"description": "すべての拡張機能を再読み込みします"
+			},
+			"revealInFileExplorer": {
+				"name": "プロジェクトフォルダーを開く",
+				"description": "システムのファイルエクスプローラーでプロジェクトフォルダーを開きます"
+			},
+			"toggleFileExplorer": {
+				"name": "ファイルエクスプローラーを切り替える",
+				"description": "ファイルエクスプローラーを開くか閉じるかを切り替える"
+			}
 		},
-		"undo": {
-			"name": "元に戻す",
-			"description": "直前の操作を元に戻す"
+		"rebinding": "再割り当て",
+		"unbound": "未割り当て",
+		"tabActions": "タブの操作",
+		"unknown": {
+			"name": "不明なアクション",
+			"description": "このアクションは存在しません！"
 		},
-		"redo": {
-			"name": "やり直し",
-			"description": "直前の操作をやり直す"
-		},
-		"goToDefinition": {
-			"name": "定義へ移動",
-			"description": "選択したシンボルの定義に移動"
-		},
-		"goToSymbol": {
-			"name": "シンボルへ移動",
-			"description": "移動するシンボルを選択するダイアログを開く"
-		},
-		"formatDocument": {
-			"name": "ドキュメントのフォーマット",
-			"description": "現在開いているドキュメントをフォーマットする"
-		},
-		"changeAllOccurrences": {
-			"name": "すべての出現個所を変更",
-			"description": "選択されたテキストのすべての出現箇所を変更する"
-		},
-		"tgaMaskToggle": {
-			"name": "Alphaチャンネルの切替"
-		},
-		"recompileChanges": {
-			"name": "変更時にコンパイルする",
-			"description": "bridge. なしで編集されたすべてのファイルをコンパイルします ウォッチモードを無効にした後エディター自体で行われた変更はコンパイルされません"
+		"tabs": {
+			"close": {
+				"name": "タブを閉じる",
+				"description": "選択されているタブを閉じる"
+			},
+			"closeAll": {
+				"name": "すべて閉じる",
+				"description": "すべてのタブを閉じる"
+			},
+			"closeOther": {
+				"name": "このタブ以外のすべてを閉じる",
+				"description": "現在選択されているタブ以外のすべての開いているタブを閉じる"
+			},
+			"closeSaved": {
+				"name": "保存されているすべてを閉じる",
+				"description": "保存されているすべてのタブを閉じる"
+			},
+			"closeToRight": {
+				"name": "右側をすべて閉じる",
+				"description": "現在選択されているタブの右側に開いているタブをすべて閉じる"
+			},
+			"keepOpen": {
+				"name": "タブを開いたままにする",
+				"description": "タブを開いたままにして、誤って閉じないようにします"
+			},
+			"name": "タブ",
+			"splitscreen": {
+				"name": "分割画面",
+				"description": "分割画面でタブを表示する"
+			}
 		}
 	},
 	"toolbar": {
@@ -445,6 +515,9 @@
 		},
 		"edit": {
 			"name": "編集"
+		},
+		"settings": {
+			"name": "設定"
 		},
 		"download": {
 			"name": "ダウンロード"
@@ -532,6 +605,12 @@
 		}
 	},
 	"sidebar": {
+		"fileExplorer": {
+			"name": "ファイルエクスプローラー"
+		},
+		"findAndReplace": {
+			"name": "検索と置換"
+		},
 		"quickExport": {
 			"name": "クイックエクスポート"
 		},
@@ -568,6 +647,10 @@
 			},
 			"actions": {
 				"runLastProfile": "最新のプロファイルを実行する"
+			},
+			"build": {
+				"name": "ビルド",
+				"description": "デフォルトのビルドプロファイルを実行する"
 			}
 		},
 		"extensions": {
@@ -633,28 +716,56 @@
 			"name": "Education Edition の有効化",
 			"description": "物質還元レシピなどの教育機能で自動補完機能を有効にします。"
 		},
-		"experimentalCreatorCameraFeatures": {
-			"name": "実験的なクリエイターカメラ機能",
-			"description": "実験的なカメラプリセット機能に対する自動補完機能を有効にします。"
+		"aimAssist": {
+			"description": "エイムアシストのプリセットやカテゴリを作成できるようになります。",
+			"name": "エイムアシスト"
+		},
+		"customComponentsV2": {
+			"description": "パラメータを使用してカスタム コンポーネントを有効にします。",
+			"name": "カスタムコンポーネント V2"
 		},
 		"dataDrivenJigsawStructures": {
-			"name": "データ駆動型ジグソー構造",
-			"description": "ジグソー構造、テンプレートプール、プロセッサーリスト、構造セットの作成を有効にします。"
+			"description": "ジグソー構造、テンプレートプール、プロセッサリスト、および構造セットの作成が可能になります。",
+			"name": "データ駆動型ジグソー構造"
+		},
+		"experimentDeprecation": {
+			"hcfDescription": "ホリデー クリエイター機能の実験は 1.21.20 で削除され、ブロック イベントとアイテム イベントはカスタム コンポーネントに置き換えられます。",
+			"title": "今後の実験の廃止予定"
+		},
+		"experimentalCreatorCameraFeatures": {
+			"description": "実験的なカメラのプリセット機能のオートコンプリートを有効にします。",
+			"name": "実験的なクリエイターのカメラ機能"
+		},
+		"experimentalCustomProjectileFeatures": {
+			"description": "実験的なカスタムプロジェクタイル機能のオートコンプリートを有効にします。",
+			"name": "カスタムプロジェクタイルの機能"
+		},
+		"experimentalVoxelShapeFeatures": {
+			"description": "実験的なボクセルシェイプ機能のオートコンプリートを有効にします。",
+			"name": "ボクセルシェイプ機能"
+		},
+		"focusTargetCamera": {
+			"description": "カメラ エンティティ ターゲティングのオートコンプリートを有効にします。",
+			"name": "クリエーターカメラ: フォーカスターゲットカメラ"
 		},
 		"renderDragonFeatures": {
-			"name": "クリエイター向けRender Dragonの機能",
-			"description": "遅延レンダリング設定ファイルの作成を可能にします。"
+			"description": "遅延レンダリング設定ファイルの作成を有効にします。",
+			"name": "クリエイター向けRender Dragon機能"
 		}
 	},
 	"windows": {
 		"sidebar": {
 			"disabledItem": "このアイテムは無効です"
 		},
-		"error": {
-			"explanation": "bridge. で以下のエラーが発生しました"
+		"reportError": {
+			"title": "エラーを報告する",
+			"explanation": "bridge. で次のエラーが発生しました：",
+			"discord": "Discord",
+			"github": "GitHub",
+			"copy": "コピー"
 		},
-		"changelogWindow": {
-			"title": "What's new?"
+		"about": {
+			"title": "このアプリについて"
 		},
 		"openFile": {
 			"title": "開く",
@@ -673,23 +784,44 @@
 			"omitPack": "省略可",
 			"selectedPack": "選択済み",
 			"title": "プロジェクトの作成",
-			"packIcon": "プロジェクトアイコン（任意)",
-			"projectName": {
-				"name": "プロジェクト名",
-				"invalidLetters": "使用できる文字は半角英数字のみです",
-				"mustNotBeEmpty": "プロジェクト名を入力する必要があります",
-				"endsInPeriod": "プロジェクト名の末尾にピリオドを使用することはできません"
-			},
-			"projectDescription": "プロジェクトの説明（任意)",
-			"projectPrefix": "プロジェクト名",
-			"projectAuthor": "プロジェクト作成者",
-			"projectTargetVersion": "プロジェクトの対象バージョン",
 			"rpAsBpDependency": "リソースパックをビヘイビアパックの依存関係として登録する",
 			"bpAsRpDependency": "ビヘイビアパックをリソースパックの依存関係として登録する",
 			"useLangForManifest": "マニフェストにパック名/説明文を直接追加する",
 			"bdsProject": "Bedrock Dedicated Server で使用するためのプロジェクトを設定する",
 			"create": "作成",
 			"saveCurrentProject": "新しいプロジェクトを作成する前に現在のプロジェクトを保存しますか？ 保存されていない変更点は失われてしまいます",
+			"icon": {
+				"label": "アイコン",
+				"placeholder": "プロジェクトアイコン（任意）"
+			},
+			"name": {
+				"label": "名前",
+				"placeholder": "プロジェクト名",
+				"invalidLetters": "プロジェクト名に次の文字を含めることはできません: \"  \\ / : | < >  * ? ~",
+				"mustNotBeEmpty": "プロジェクト名を入力してください",
+				"endsInPeriod": "プロジェクト名はピリオドで終わることはできません",
+				"alreadyExists": "この名前のプロジェクトはすでに存在します"
+			},
+			"description": {
+				"label": "説明",
+				"placeholder": "プロジェクトの説明（任意）"
+			},
+			"namespace": {
+				"label": "名前空間",
+				"placeholder": "プロジェクトの名前空間",
+				"invalidCharacters": "プロジェクト名前空間には英数字とアンダースコア(_)のみを使用できます",
+				"mustNotBeEmpty": "プロジェクト名前空間を入力してください"
+			},
+			"author": {
+				"label": "作成者",
+				"placeholder": "プロジェクト作成者名（任意）"
+			},
+			"targetVersion": {
+				"label": "ターゲットバージョン"
+			},
+			"errors": {
+				"noPacks": "プロジェクトには少なくとも1つのパックを含める必要があります。"
+			},
 			"individualFiles": {
 				"name": "個別ファイル",
 				"file": {
@@ -734,11 +866,12 @@
 						"description": "プロジェクト内の他の場所で使用するサウンドファイルのIDを定義します。"
 					},
 					"splashes": {
-						"name": "splashes.json",
-						"description": "Minecraftのタイトル画面に表示されるスプラッシュメッセージの定義に使用されます。"
+						"description": "タイトル画面のスプラッシュメッセージを定義するために使用されます。",
+						"name": "splash.json"
 					}
 				}
-			}
+			},
+			"replaceCurrentProject": "新しいプロジェクトを作成すると、既存のプロジェクトは上書きされます。確定した場合でも、新しいプロジェクトを開いている間は、古いプロジェクトのエクスポートデータをダウンロードすることが可能です。"
 		},
 		"createPreset": {
 			"title": "プリセットの作成",
@@ -898,6 +1031,13 @@
 				"hideToolbarItems": {
 					"name": "ツールバーの項目を非表示にする",
 					"description": "MacOS で bridge. を快適に利用するためにすべてのツールバーのアイテムを新しいメニューボタンに移動します"
+				},
+				"fileExplorerIndentation": {
+					"name": "ファイルエクスプローラーのインデント",
+					"description": "ファイルエクスプローラー内のフォルダーのインデントを変更します"
+				},
+				"sidebarElementVisibility": {
+					"name": "サイドバー要素の表示"
 				}
 			},
 			"general": {
@@ -914,10 +1054,6 @@
 					"name": "Pack Spider",
 					"description": "Pack Spider はプロジェクト内のファイルを接続し、その接続を仮想ファイルシステムで表示します。"
 				},
-				"formatOnSave": {
-					"name": "保存時のフォーマット",
-					"description": "テキストファイルの保存時にフォーマットを行います"
-				},
 				"openLinksInBrowser": {
 					"name": "リンクをデフォルトのブラウザで開く",
 					"description": "ネイティブアプリのウィンドウではなく、デフォルトのブラウザでリンクを開きます"
@@ -933,6 +1069,10 @@
 				"resetBridgeFolder": {
 					"name": "ルートフォルダーのリセット",
 					"description": "アプリをリセットして、bridge. v2のデフォルトのルートフォルダーを再び使用するようにします。"
+				},
+				"keepTabsOpen": {
+					"name": "タブを開いたままにする",
+					"description": "デフォルトでは、新しいタブを開くと、操作されていない前のタブが閉じられます"
 				}
 			},
 			"developer": {
@@ -948,6 +1088,10 @@
 				"forceDataDownload": {
 					"name": "強制データダウンロード",
 					"description": "キャッシュされたアプリデータを無視し、代わりに最新のデータをダウンロードします"
+				},
+				"dataDeveloperMode": {
+					"name": "データ開発者モード",
+					"description": "データキャッシュを無視し、組み込みパッケージから読み込みます"
 				}
 			},
 			"actions": {
@@ -958,6 +1102,10 @@
 				"defaultAuthor": {
 					"name": "デフォルトの著者",
 					"description": "新しいプロジェクトのデフォルトの著者を設定します"
+				},
+				"defaultNamespace": {
+					"name": "デフォルトの名前空間",
+					"description": "新しいプロジェクトのデフォルトの名前空間を設定します"
 				},
 				"loadComMojangProjects": {
 					"name": "com.mojang プロジェクトの読み込み",
@@ -970,14 +1118,28 @@
 				"addGeneratedWith": {
 					"name": "\"generated_with\"の追加",
 					"description": "プロジェクトのマニフェストに \"generated_with\" メタデータを追加します"
+				},
+				"clearOutputFolder": {
+					"name": "出力フォルダーをクリア",
+					"description": "現在のデフォルト出力フォルダを無視する。"
+				},
+				"outputFolder": {
+					"name": "出力フォルダー",
+					"button": "出力フォルダーを選択",
+					"description": "出力フォルダーをここにドロップしてください。",
+					"warning": {
+						"notSupported": "このプラットフォームでは、出力フォルダの選択はサポートされていません",
+						"notSet": "デフォルトの出力フォルダが設定されていません！",
+						"overwritten": "デフォルトの出力フォルダが、プロジェクトの出力フォルダによって上書きされています"
+					}
 				}
 			},
 			"editor": {
+				"name": "エディタ",
 				"jsonEditor": {
 					"name": "JSON エディタ",
 					"description": "JSONファイルの編集方法を選択します"
 				},
-
 				"bracketPairColorization": {
 					"name": "ブラケットペアのカラーリング",
 					"description": "対になっているブラケットに色をつけます"
@@ -993,10 +1155,6 @@
 				"compactTabDesign": {
 					"name": "コンパクトなタブ",
 					"description": "タブをよりコンパクトに表示します"
-				},
-				"keepTabsOpen": {
-					"name": "タブを開いたままにする",
-					"description": "デフォルトでは新しいタブを開くと、それまで開いていたタブが操作されていない場合閉じられます"
 				},
 				"autoSaveChanges": {
 					"name": "変更を自動保存",
@@ -1026,9 +1184,13 @@
 					"name": "配列のインデックスを表示する",
 					"description": "ツリーエディターで配列要素のインデックスを表示する"
 				},
-				"hideBracketsWithinTreeEditor": {
+				"hideBrackets": {
 					"name": "ブラケットを隠す",
-					"description": "ツリーエディターでブラケットを非表示にする"
+					"description": "bridge. のツリーエディタ内でブラケットを隠します"
+				},
+				"formatOnSave": {
+					"name": "保存時にフォーマット",
+					"description": "ファイルを保存するときにテキストファイルをフォーマットします"
 				}
 			}
 		},
@@ -1058,11 +1220,19 @@
 				"description2": "のマニフェストは無効です。この問題を解決するために、拡張機能の作者に連絡することを検討してください。"
 			}
 		},
+		"alert": {
+			"title": "警告"
+		},
+		"progress": {
+			"title": "読み込み中"
+		},
 		"pluginInstallLocation": {
 			"title": "インストール先の選択"
 		},
 		"unsavedFile": {
 			"description": "このファイルを閉じる前に変更内容を保存しますか？",
+			"closeFile": "変更を保存せずに閉じようとしています。本当にウィンドウを閉じますか？",
+			"closeProject": "プロジェクトを閉じる前に変更内容を保存しますか？",
 			"save": "保存して閉じる"
 		},
 		"browserUnsupported": {
@@ -1082,6 +1252,40 @@
 		"upgradeFs": {
 			"title": "ファイルシステムのアップグレード",
 			"description": "お使いのブラウザがファイルを直接コンピュータに保存する機能に対応しました。今すぐアップグレードしますか？"
+		},
+		"editProject": {
+			"author": {
+				"label": "著者",
+				"placeholder": "プロジェクト作成者 (オプション)"
+			},
+			"bpAsRpDependency": "ビヘイビアー パックをリソース パックの依存関係として登録する",
+			"description": {
+				"label": "説明",
+				"placeholder": "プロジェクトの説明 (オプション)"
+			},
+			"errors": {
+				"noPacks": "プロジェクトには少なくとも 1 つのパックが含まれている必要があります"
+			},
+			"name": {
+				"alreadyExists": "この名前のプロジェクトはすでに存在します",
+				"endsInPeriod": "プロジェクト名をピリオドで終わらせることはできません",
+				"invalidLetters": "プロジェクト名には次の文字を含めることはできません: \"  \\ / : | < >  * ? ~",
+				"label": "名前",
+				"mustNotBeEmpty": "プロジェクト名を入力する必要があります",
+				"placeholder": "プロジェクト名"
+			},
+			"namespace": {
+				"invalidCharacters": "プロジェクトの名前空間には英数字とアンダースコアのみを含める必要があります",
+				"label": "名前空間",
+				"mustNotBeEmpty": "プロジェクトの名前空間を入力する必要があります",
+				"placeholder": "プロジェクトの名前空間"
+			},
+			"rpAsBpDependency": "リソース パックをビヘイビアー パックの依存関係として登録する",
+			"save": "保存",
+			"targetVersion": {
+				"label": "対象バージョン"
+			},
+			"title": "プロジェクトの編集"
 		}
 	},
 	"taskManager": {
@@ -1115,6 +1319,10 @@
 					"name": "出力フォルダー",
 					"description": "このフォルダーを新しい出力フォルダーとして設定する"
 				},
+				"project": {
+					"name": "新規プロジェクト",
+					"description": "このフォルダーを新しいプロジェクトとしてインポートする"
+				},
 				"open": {
 					"name": "フォルダーを開く",
 					"description": "このフォルダーを bridge. のファイルエクスプローラで開きます"
@@ -1126,12 +1334,12 @@
 		},
 		"saveToProject": {
 			"title": "プロジェクトへの保存",
-			"description1": "",
+			"description1": "ファイルを保存する",
 			"description2": "をプロジェクト内に保存します"
 		},
 		"openFile": {
 			"title": "ファイルを開く",
-			"description1": "",
+			"description1": "ファイルを開く",
 			"description2": "を開き編集した内容を元のファイルに保存します"
 		}
 	},
@@ -1172,6 +1380,7 @@
 		"chooseGeometry": "ジオメトリの選択",
 		"chooseTexture": "テクスチャの選択",
 		"noGeometry": "このファイル内に有効なジオメトリが見つかりません。 JSON が有効であること、ファイル構造が正しいこと、および指定された識別子を持つジオメトリが存在することを確認してください。",
+		"noTextures": "このファイル内に有効なテクスチャが見つかりません。 JSON が有効であること、ファイル構造が正しいこと、および指定された識別子を持つテクスチャが存在することを確認してください。",
 		"lootTableSimulator": {
 			"emptyLootOutput": "出力が空です。実行して結果を出力してください。",
 			"data": {
@@ -1242,6 +1451,7 @@
 			"addArray": "配列の追加",
 			"addValue": "値の追加",
 			"forceValue": "必須",
+			"convert": "変換",
 			"edit": "編集",
 			"childHasError": "子要素に1件以上の問題があります"
 		},
@@ -1292,7 +1502,11 @@
 			"tokens": {
 				"selectorArgument": "セレクター引数"
 			}
-		}
+		},
+		"invalidLetters": "特殊文字を含んではいけません",
+		"mustNotBeEmpty": "空欄にしてはいけません",
+		"mustBeLowercase": "小文字で入力してください",
+		"mustBeNumeric": "数字でなければなりません"
 	},
 	"bottomPanel": {
 		"terminal": {
@@ -1306,5 +1520,38 @@
 			"name": "コンパイラ",
 			"noLogs": "ログはありません"
 		}
+	},
+	"greet": {
+		"projects": "プロジェクト",
+		"noProjects": "まだプロジェクトがありません。",
+		"createOne": "作成する",
+		"pin": "ピン留め",
+		"unpin": "ピン留めを解除",
+		"noBridgeFolderSelected": "bridge. フォルダを選択する必要があります。",
+		"selectBridgeFolder": "bridge. フォルダを選択"
+	},
+	"convert": {
+		"confirmationMessage": {
+			"v1": "これは bridge. v1 プロジェクトです。「続行」をクリックすると、このプロジェクトは bridge. プロジェクトに変換され、bridge. projects フォルダに保存されます。",
+			"com": {
+				"mojang": "bridge. は com.mojang フォルダ内のプロジェクトを直接開くことをサポートしなくなりました。「続行」をクリックすると、このプロジェクトは bridge. プロジェクトに変換され、bridge. projects フォルダに保存されます。"
+			}
+		}
+	},
+	"projects": {
+		"clearOutputFolder": {
+			"name": "プロジェクトの出力フォルダをクリアする",
+			"description": "現在のプロジェクトの出力フォルダは無視してください"
+		},
+		"outputFolder": {
+			"button": "プロジェクトの出力フォルダを選択してください",
+			"description": "このプロジェクトのコンパイル結果が保存される出力フォルダ",
+			"warning": {
+				"notSupported": "このプラットフォームでは、出力フォルダの選択はサポートされていません",
+				"using": "このプロジェクトでは、ローカルのプロジェクトフォルダを使用しています",
+				"notUsing": "このプロジェクトでは、ローカルのプロジェクトフォルダを使用していません"
+			}
+		},
+		"loading": "プロジェクトを読み込んでいます..."
 	}
 }


### PR DESCRIPTION
## Description
This is a follow-up to #1441. Since v3.0.2 has been moved from the upd/refactor branch to the main branch, I have recreated the pull request.
## Motivation
With the transition to v3, the number of English strings has increased due to the introduction of new translation keys. Therefore, we have updated the translations to match the new keys and removed any unused keys.
## Additional Context
This translation is based on en.json. While working on it, I encountered keys that do not exist in en.json, but I ignored them. Additionally, the structure—such as the placement of keys—may differ slightly from en.json, but it functions correctly.