### PR TITLE
fix: added guard statement to ensure content is loaded before opening it

### DIFF
--- a/src/components/Greet/Greet.vue
+++ b/src/components/Greet/Greet.vue
@@ -49,10 +49,14 @@ async function openProject(project: ProjectInfo) {
 }
 
 async function edit(name: string) {
+	if (fileSystem instanceof PWAFileSystem && !fileSystem.setup) await loadBridgeFolder()
+	// second check for permissions
+	if (fileSystem instanceof PWAFileSystem && !fileSystem.setup) return
+
 	const projectInfo = await ProjectManager.getProjectInfo(join('/projects', name))
 
 	if(!projectInfo) throw new Error("Failed to get project info!")
-	
+
 	EditProjectWindow.open(projectInfo)
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/bridge-core/editor/issues/1637

## Motivation
Resolve issue as per issue, also ran into this issue myself

## Additional Context
none