### PR TITLE
fix: preset file selection + FS access fallback bugs (save + delete)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -82,7 +82,16 @@ export async function setup() {
 
 	if (fileSystem instanceof TauriFileSystem) await setupTauriFileSystem()
 
-	if (fileSystem instanceof LocalFileSystem) fileSystem.setRootName('fileSystemPolyfill')
+	if (fileSystem instanceof LocalFileSystem) {
+		fileSystem.setRootName('fileSystemPolyfill')
+
+		// On browsers without the File System Access API (e.g. Safari, Firefox, Android Chrome) the
+		// entire project lives in IndexedDB. Request persistent storage so the browser doesn't evict
+		// it, which otherwise causes saved files to silently disappear.
+		if (navigator.storage?.persist) {
+			navigator.storage.persist().catch(() => {})
+		}
+	}
 
 	setupTypescript()
 	setupLang()

--- a/src/components/Windows/Presets/Presets.vue
+++ b/src/components/Windows/Presets/Presets.vue
@@ -76,6 +76,32 @@ const validationError: ComputedRef<string | null> = computed(() => {
 	return null
 })
 
+function openFileInput(fieldId: string) {
+	const input = document.getElementById(`preset-file-input-${fieldId}`)
+
+	if (input instanceof HTMLInputElement) input.click()
+}
+
+async function onFileInputChange(event: Event, fieldId: string) {
+	const input = <HTMLInputElement>event.target
+
+	const file = input.files?.[0]
+
+	if (!file) return
+
+	const content = new Uint8Array(await file.arrayBuffer())
+
+	// Store a fake file handle matching the shape that preset scripts (and loadPresetFile) expect:
+	// `name` + `content` (binary, read by createFile) + `text()` (read by e.g. the Block Model script).
+	createPresetOptions.value[fieldId] = {
+		name: file.name,
+		content,
+		async text() {
+			return new TextDecoder().decode(content)
+		},
+	}
+}
+
 async function create() {
 	if (validationError.value !== null) return
 
@@ -214,15 +240,22 @@ watch(filteredCategories, () => {
 								class="mb-6 flex bg-background"
 								v-slot="{ focus, blur }"
 							>
-								<input type="file" class="hidden" />
+								<input
+									:id="`preset-file-input-${fieldId}`"
+									type="file"
+									class="hidden"
+									:accept="fieldOptions.accept"
+									@change="(event: Event) => onFileInputChange(event, fieldId)"
+								/>
 
 								<button
 									class="flex align-center gap-2 text-text-secondary font-theme placeholder:text-text-secondary"
 									@mouseenter="focus"
 									@mouseleave="blur"
+									@click="openFileInput(fieldId)"
 								>
 									<Icon icon="image" class="no-fill" color="text-text-secondary" />
-									{{ fieldName }}
+									{{ createPresetOptions[fieldId]?.name ?? fieldName }}
 								</button>
 							</LabeledInput>
 

--- a/src/components/Windows/Presets/Presets.vue
+++ b/src/components/Windows/Presets/Presets.vue
@@ -9,7 +9,7 @@ import Switch from '@/components/Common/Switch.vue'
 import Dropdown from '@/components/Common/Legacy/LegacyDropdown.vue'
 
 import { useTranslate } from '@/libs/locales/Locales'
-import { ComputedRef, Ref, computed, ref, watch } from 'vue'
+import { ComponentPublicInstance, ComputedRef, Ref, computed, ref, watch } from 'vue'
 import { BedrockProject } from '@/libs/project/BedrockProject'
 import { ProjectManager } from '@/libs/project/ProjectManager'
 import { Windows } from '../Windows'
@@ -76,10 +76,18 @@ const validationError: ComputedRef<string | null> = computed(() => {
 	return null
 })
 
-function openFileInput(fieldId: string) {
-	const input = document.getElementById(`preset-file-input-${fieldId}`)
+const fileInputs: { [key: string]: HTMLInputElement } = {}
 
-	if (input instanceof HTMLInputElement) input.click()
+function setFileInput(fieldId: string, element: Element | ComponentPublicInstance | null) {
+	if (element instanceof HTMLInputElement) {
+		fileInputs[fieldId] = element
+	} else {
+		delete fileInputs[fieldId]
+	}
+}
+
+function openFileInput(fieldId: string) {
+	fileInputs[fieldId]?.click()
 }
 
 async function onFileInputChange(event: Event, fieldId: string) {
@@ -241,7 +249,7 @@ watch(filteredCategories, () => {
 								v-slot="{ focus, blur }"
 							>
 								<input
-									:id="`preset-file-input-${fieldId}`"
+									:ref="(element) => setFileInput(fieldId, element)"
 									type="file"
 									class="hidden"
 									:accept="fieldOptions.accept"

--- a/src/components/Windows/Presets/Presets.vue
+++ b/src/components/Windows/Presets/Presets.vue
@@ -9,7 +9,7 @@ import Switch from '@/components/Common/Switch.vue'
 import Dropdown from '@/components/Common/Legacy/LegacyDropdown.vue'
 
 import { useTranslate } from '@/libs/locales/Locales'
-import { ComponentPublicInstance, ComputedRef, Ref, computed, ref, watch } from 'vue'
+import { ComponentPublicInstance, ComputedRef, Ref, computed, onMounted, ref, watch } from 'vue'
 import { BedrockProject } from '@/libs/project/BedrockProject'
 import { ProjectManager } from '@/libs/project/ProjectManager'
 import { Windows } from '../Windows'
@@ -39,11 +39,13 @@ watch(selectedPreset, () => {
 
 let availablePresets: Ref<{ [key: string]: any }> = ref({})
 
-if (ProjectManager.currentProject && ProjectManager.currentProject instanceof BedrockProject) {
-	availablePresets = ProjectManager.currentProject.presetData.useAvailablePresets()
+onMounted(() => {
+	if (ProjectManager.currentProject && ProjectManager.currentProject instanceof BedrockProject) {
+		availablePresets = ProjectManager.currentProject.presetData.useAvailablePresets()
 
-	selectedPresetPath.value = Object.keys(availablePresets.value)[0] ?? null
-}
+		selectedPresetPath.value = Object.keys(availablePresets.value)[0] ?? null
+	}
+})
 
 const categories: ComputedRef<{ [key: string]: string[] }> = computed(() => {
 	const categories: { [key: string]: string[] } = {}
@@ -263,7 +265,7 @@ watch(filteredCategories, () => {
 									@click="openFileInput(fieldId)"
 								>
 									<Icon icon="image" class="no-fill" color="text-text-secondary" />
-									{{ createPresetOptions[fieldId]?.name ?? fieldName }}
+									{{ fieldName }}
 								</button>
 							</LabeledInput>
 

--- a/src/libs/compiler/DashService.ts
+++ b/src/libs/compiler/DashService.ts
@@ -71,10 +71,7 @@ export class DashService implements AsyncDisposable {
 		await sendAndWait(
 			{
 				action: 'setup',
-				// Pass a plain, structured-clone-safe copy of the config. Safari's structured clone
-				// is stricter than Chromium's and throws DataCloneError on non-plain objects, which
-				// broke .mcaddon exports (the only export path that hands data to the Dash worker).
-				config: this.project.config ? JSON.parse(JSON.stringify(this.project.config)) : this.project.config,
+				config: this.project.config,
 				mode,
 				configPath: join(this.project.path, 'config.json'),
 				compilerConfigPath,

--- a/src/libs/compiler/DashService.ts
+++ b/src/libs/compiler/DashService.ts
@@ -71,7 +71,10 @@ export class DashService implements AsyncDisposable {
 		await sendAndWait(
 			{
 				action: 'setup',
-				config: this.project.config,
+				// Pass a plain, structured-clone-safe copy of the config. Safari's structured clone
+				// is stricter than Chromium's and throws DataCloneError on non-plain objects, which
+				// broke .mcaddon exports (the only export path that hands data to the Dash worker).
+				config: this.project.config ? JSON.parse(JSON.stringify(this.project.config)) : this.project.config,
 				mode,
 				configPath: join(this.project.path, 'config.json'),
 				compilerConfigPath,

--- a/src/libs/fileSystem/LocalFileSystem.ts
+++ b/src/libs/fileSystem/LocalFileSystem.ts
@@ -173,7 +173,14 @@ export class LocalFileSystem extends BaseFileSystem {
 
 		path = resolve('/', path)
 
-		await del(`localFileSystem/${this.rootName}${path}`)
+		// Remove the directory entry itself as well as every file and subdirectory nested inside of it.
+		// idb-keyval has no concept of folders, so deleting only the directory key would orphan its children.
+		const directoryKey = `localFileSystem/${this.rootName}${path}`
+		const childPrefix = `${directoryKey}/`
+
+		const childKeys = (await keys()).filter((key) => key.toString().startsWith(childPrefix))
+
+		await Promise.all([del(directoryKey), ...childKeys.map((key) => del(key))])
 
 		if (
 			this.pathsToWatch.find((watchPath) => path.startsWith(watchPath)) !== undefined &&


### PR DESCRIPTION
## Description

Fixes 3 reported bugs. One is a cross platform regression in the "new file" preset window. The other three are all in the fallback file system path used by browser without the file system access API (various browsers).

## Motivation
| Issue | Bug |
|-------|-----|
| #1653, #1630 | Selecting a model/texture in "New File" does nothing |
| #1669 (1) | Folders can't be deleted in Safari/Firefox |
| #1667 | Saved files don't persist on Android |